### PR TITLE
Use prowjob to setup GH webhooks + hmac secret

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -37,6 +37,17 @@ plank:
           requests:
             cpu: 100m
 
+managed_webhooks:
+  # This has to be true if any of the managed repo/org is using the legacy global token that is manually created.
+  respect_legacy_global_token: true
+  
+  # Config for orgs and repos that have been onboarded to this Prow instance.
+  org_repo_config:
+    jetstack/testing:
+      token_created_after: 2023-04-13T00:00:00Z
+    cert-manager:
+      token_created_after: 2023-04-13T00:00:00Z
+
 # branch-protection is well documented in the source code for prow:
 # https://github.com/kubernetes/test-infra/blob/bc7ab92094413c3ba659851b5ec19f4308cb3a70/prow/config/branch_protection.go
 branch-protection:

--- a/config/jobs/testing/testing-postsubmits-trusted.yaml
+++ b/config/jobs/testing/testing-postsubmits-trusted.yaml
@@ -38,6 +38,43 @@ postsubmits:
           requests:
             memory: "1Gi"
 
+  - name: post-testing-reconcile-hmacs
+    cluster: trusted
+    run_if_changed: 'config/config.yaml'
+    decorate: true
+    branches:
+    - master
+    annotations:
+      testgrid-dashboards: jetstack-testing-janitors
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    labels:
+      preset-deployer-github-token: "true"
+    max_concurrency: 1
+    spec:
+      containers:
+      - image: gcr.io/k8s-prow/hmac:v20200622-168a90f1b0
+        command:
+        - /hmac
+        args:
+        - --config-path=config/config.yaml
+        - --hook-url=https://prow.build-infra.jetstack.net/hook
+        - --hmac-token-secret-name=hmac-token-new
+        - --hmac-token-key=hmac
+        - --kubeconfig=/etc/kubeconfig/config
+        - --kubeconfig-context=prow-services
+        - --github-token-path=/etc/github/token
+        - --github-endpoint=https://api.github.com
+        - --dry-run=true # set this to false once configured correctly
+        volumeMounts:
+        - name: kubeconfig
+          mountPath: /etc/kubeconfig
+          readOnly: true
+      volumes:
+      - name: kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-prow-services
+
   - name: post-testing-push-bazelbuild
     cluster: trusted
     run_if_changed: '^images/bazelbuild/'


### PR DESCRIPTION
see: https://docs.prow.k8s.io/docs/components/optional/hmac/

Currently, it seems like the GH webhooks are configured manually.

GH uses a HMAC secret to sign events that are sent to the prow webhook.
This prowjob should automatically generate the HMAC secret and create the webhooks in GH.
The HMAC secret should be created in the "prowjob" cluster, this prowjob is created in the "trusted" cluster however (so we still have to create a kubeconfig secret).
Configuring this setup here will make it easier to rotate HMAC secrets & create new clusters.

Plan of action:
- create a secret in the "prowjob" cluster that contains the kubeconfig of the "trusted" cluster
- merge & run the prowjob
- set `dry-run=false`, which should result in the `hmac-token-new` secret being created
- try using the new `hmac-token-new` secret
- remove the old webhook configs in GH
