### PR TITLE
Moving jetstack/testing to cert-manager/testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ local-checkconfig:
         --default=config/testgrid/default.yaml \
         --prow-config=/config/config.yaml \
         --prow-job-config=/config/jobs \
-        --prowjob-url-prefix=https://github.com/jetstack/testing/tree/master/config/jobs \
+        --prowjob-url-prefix=https://github.com/cert-manager/testing/tree/master/config/jobs \
         --update-description \
         --validate-config-file \
         --oneshot

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jetstack/testing
+# cert-manager/testing
 
 This repository contains the configuration used for testing all jetstck projects.
 

--- a/config/autobump-config/testing-autobump-config.yaml
+++ b/config/autobump-config/testing-autobump-config.yaml
@@ -8,7 +8,7 @@ gitHubOrg: "jetstack"
 gitHubRepo: "testing"
 remoteName: "testing"
 headBranchName: "autobump"
-upstreamURLBase: "https://raw.githubusercontent.com/jetstack/testing/master"
+upstreamURLBase: "https://raw.githubusercontent.com/cert-manager/testing/master"
 includedConfigPaths:
   - "config/jobs"
   - "images"
@@ -24,6 +24,6 @@ prefixes:
     consistentImages: false
   - name: "jetstack-build-infra images"
     prefix: "eu.gcr.io/jetstack-build-infra-images/"
-    repo: "https://github.com/jetstack/testing"
+    repo: "https://github.com/cert-manager/testing"
     summarise: false
     consistentImages: false

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -238,7 +238,7 @@ tide:
     - do-not-merge/release-note-label-needed
   # Maintain separate testing configuration as PRs in this repo don't need release note
   - repos:
-    - jetstack/testing
+    - cert-manager/testing
     labels:
     - lgtm
     - approved

--- a/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
+++ b/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
@@ -19,7 +19,7 @@ presubmits:
           requests:
             # 3500m was chosen because that allows us to fit two jobs onto one
             # n1-standard-8 node, taking into account the amount of CPU allocated
-            # to the kubelet. https://github.com/jetstack/testing/pull/510
+            # to the kubelet. https://github.com/cert-manager/testing/pull/510
             cpu: 3500m
             memory: 4Gi
       dnsConfig:

--- a/config/jobs/testing/testing-periodics-trusted.yaml
+++ b/config/jobs/testing/testing-periodics-trusted.yaml
@@ -105,7 +105,7 @@ periodics:
   annotations:
     testgrid-dashboards: jetstack-testing-janitors
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Creates autobump PRs for the jetstack/testing repo.
+    description: Creates autobump PRs for the cert-manager/testing repo.
   extra_refs:
   - org: jetstack
     repo: testing

--- a/config/jobs/testing/testing-postsubmits-trusted.yaml
+++ b/config/jobs/testing/testing-postsubmits-trusted.yaml
@@ -1,5 +1,5 @@
 postsubmits:
-  jetstack/testing:
+  cert-manager/testing:
 
   # TestGrid (https://github.com/GoogleCloudPlatform/testgrid) is a UI
   # for Prow. We and some other kubernetes-related projects use a hosted TestGrid
@@ -30,7 +30,7 @@ postsubmits:
         - --default=config/testgrid/default.yaml
         - --prow-config=config/config.yaml
         - --prow-job-config=config/jobs
-        - --prowjob-url-prefix=https://github.com/jetstack/testing/tree/master/config/jobs
+        - --prowjob-url-prefix=https://github.com/cert-manager/testing/tree/master/config/jobs
         - --update-description
         - --output=gs://jetstack-testgrid/config
         - --oneshot

--- a/config/jobs/testing/testing-presubmits.yaml
+++ b/config/jobs/testing/testing-presubmits.yaml
@@ -1,6 +1,6 @@
 presubmits:
 
-  jetstack/testing:
+  cert-manager/testing:
 
   - name: pull-testing-config
     always_run: true
@@ -73,7 +73,7 @@ presubmits:
         - --default=config/testgrid/default.yaml
         - --prow-config=config/config.yaml
         - --prow-job-config=config/jobs
-        - --prowjob-url-prefix=https://github.com/jetstack/testing/tree/master/config/jobs
+        - --prowjob-url-prefix=https://github.com/cert-manager/testing/tree/master/config/jobs
         - --update-description
         - --validate-config-file
         - --oneshot

--- a/config/labels.yaml
+++ b/config/labels.yaml
@@ -83,54 +83,6 @@ repos:
       target: both
       addedBy: prow
 
-  jetstack/testing:
-    labels:
-    - color: 0052cc
-      description: Indicates a PR related to cert-manager
-      name: area/cert-manager
-      target: both
-      addedBy: prow
-    - color: 0052cc
-      description: Indicates a PR related to tarmak
-      name: area/tarmak
-      target: both
-      addedBy: prow
-    - color: 0052cc
-      description: Indicates a PR related to testing
-      name: area/testing
-      target: both
-      addedBy: prow
-    - color: 0052cc
-      description: Indicates a PR related to kube-oidc-proxy
-      name: area/kube-oidc-proxy
-      target: both
-      addedBy: prow
-    - color: 0052cc
-      description: Indicates a PR related to flightdeck
-      name: area/flightdeck
-      target: both
-      addedBy: prow
-    - color: 0052cc
-      description: Indicates a PR related to okta-kubectl-auth
-      name: area/okta-kubectl-auth
-      target: both
-      addedBy: prow
-    - color: 0052cc
-      description: Indicates a PR related to terraform-google-gke-cluster
-      name: area/terraform-gke
-      target: both
-      addedBy: prow
-    - color: 0052cc
-      description: Indicates a PR related to prow
-      name: area/prow
-      target: both
-      addedBy: prow
-    - color: d455d0
-      description: Indicates a PR that is an automated image bump
-      name: kind/bump
-      target: both
-      addedBy: prow
-
 default:
   labels:
   - color: 0ffa16

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -4,9 +4,7 @@
 ---
 triggers:
 - repos:
-  - jetstack/testing
-  only_org_members: true
-- repos:
+  - cert-manager/testing
   - cert-manager/cert-manager
   - cert-manager/website
   - cert-manager/trust-manager
@@ -18,14 +16,6 @@ blunderbuss:
   request_count: 1
 
 external_plugins:
-  jetstack:
-  - name: needs-rebase
-    events:
-    - pull_request
-  - name: cherrypicker
-    events:
-    - issue_comment
-    - pull_request
   cert-manager:
   - name: needs-rebase
     events:
@@ -102,30 +92,6 @@ owners:
 
 plugins:
 
-  jetstack:
-    plugins:
-    - assign
-    - blockade
-    - cherry-pick-unapproved
-    - golint
-    - heart
-    - help
-    - hold
-    - label
-    - lgtm
-    - lifecycle
-    - milestone
-    - milestonestatus
-    - milestoneapplier
-    - override
-    - require-matching-label
-    - shrug
-    - size
-    - skip
-    - trigger
-    - wip
-    - yuks
-
   cert-manager:
     plugins:
     - approve
@@ -153,10 +119,6 @@ plugins:
     plugins:
     - release-note
 
-  jetstack/testing:
+  cert-manager/testing:
     plugins:
-    - approve
     - config-updater
-    - dco
-    - owners-label
-    - verify-owners

--- a/images/README.md
+++ b/images/README.md
@@ -9,10 +9,10 @@ Most images are built using the scripts in [images/builder](./builder).
 ## When does a new image get built/will my change trigger a new build?
 
 There is a Prow post-submit job that builds the image for each of the images in ./config/jobs/testing/testing-trusted.yaml.
-Each of these jobs will get triggered after a change to a subdirectory in ./images, for example the job that builds new 'golang-nodejs' image will get triggered after a change to ./images/golang-nodejs, see [its '.run_if_changed' field](https://github.com/jetstack/testing/blob/2b87fe6e34ff150042a9a776a85b3e62a20d98dc/config/jobs/testing/testing-trusted.yaml#L176).
+Each of these jobs will get triggered after a change to a subdirectory in ./images, for example the job that builds new 'golang-nodejs' image will get triggered after a change to ./images/golang-nodejs, see [its '.run_if_changed' field](https://github.com/cert-manager/testing/blob/2b87fe6e34ff150042a9a776a85b3e62a20d98dc/config/jobs/testing/testing-trusted.yaml#L176).
 
 After a PR to ./images subdirectory gets merged, you should see the Prow job that builds the new image version in https://prow.build-infra.jetstack.net/.
-(There is a known bug where sometimes these jobs appear as failed despite having succesfully built the image https://github.com/jetstack/testing/issues/602)
+(There is a known bug where sometimes these jobs appear as failed despite having succesfully built the image https://github.com/cert-manager/testing/issues/602)
 
 ## How do I add a new image?
 

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -17,21 +17,35 @@
 .PHONY: help
 help:
 	@echo "Available targets:"
+	@echo "  diff-config: diff the configmap and the prow config"
 	@echo "  update-config: update the configmap for the prow config"
+	@echo "  diff-plugins: diff the configmap and the prow plugins"
 	@echo "  update-plugins: update the configmap for the prow plugins"
 	@echo "  diff-prow: diff the current prow deployment against the desired state"
 	@echo "  deploy-prow: deploy the prow deployment"
+
+.PHONY: diff-config
+diff-config:
+	cd ../config/ && \
+	kubectl create configmap config --from-file=config.yaml=config.yaml --dry-run=client -o yaml | kubectl diff -f -
 
 # This target allows you to manually update the configmap for the prow config,
 # normally this is done through GitOps.
 .PHONY: update-config
 update-config:
+	cd ../config/ && \
 	kubectl create configmap config --from-file=config.yaml=config.yaml --dry-run=client -o yaml | kubectl replace configmap config -f -
+
+.PHONY: diff-plugins
+diff-plugins:
+	cd ../config/ && \
+	kubectl create configmap plugins --from-file=plugins.yaml=plugins.yaml --dry-run=client -o yaml | kubectl diff -f -
 
 # This target allows you to manually update the configmap for the prow plugins,
 # normally this is done through GitOps.
 .PHONY: update-plugins
 update-plugins:
+	cd ../config/ && \
 	kubectl create configmap plugins --from-file=plugins.yaml=plugins.yaml --dry-run=client -o yaml | kubectl replace configmap plugins -f -
 
 .PHONY: diff-prow

--- a/prow/cluster/labelsync_cronjob.yaml
+++ b/prow/cluster/labelsync_cronjob.yaml
@@ -33,7 +33,7 @@ spec:
               - --config=/etc/config/labels.yaml
               - --confirm=true
               # TODO: enable label_sync across the whole org
-              - --only=cert-manager/cert-manager,jetstack/testing,cert-manager/trust-manager,cert-manager/release,cert-manager/webhook-example,cert-manager/website,cert-manager/csi-lib,cert-manager/approver-policy,cert-manager/csi-driver,cert-manager/istio-csr,cert-manager/csi-driver-spiffe,cert-manager/infrastructure,cert-manager/boilersuite
+              - --only=cert-manager/cert-manager,cert-manager/testing,cert-manager/trust-manager,cert-manager/release,cert-manager/webhook-example,cert-manager/website,cert-manager/csi-lib,cert-manager/approver-policy,cert-manager/csi-driver,cert-manager/istio-csr,cert-manager/csi-driver-spiffe,cert-manager/infrastructure,cert-manager/boilersuite
               - --token=/etc/github/oauth
               volumeMounts:
               - name: oauth


### PR DESCRIPTION
https://github.com/cert-manager/testing/pull/903/commits/74fe5acbc94358e6b7e0b4d6c7c7ec3ad6325e38
 - renames all jetstack/testing occurances to cert-manager/testing
 - removes the cert-manager/testing specific labels

https://github.com/cert-manager/testing/pull/903/commits/676cd4fd4b81a976ca72711a6df2e29f48a51fed
 - updated the makefile to fix the manual update-config steps & add diff targets

closes https://github.com/cert-manager/testing/issues/904