### PR TITLE
Only protect branches master, main, and release-.*

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -51,9 +51,10 @@ branch-protection:
       required_status_checks:
         contexts:
         - dco
-      exclude:
-      # don't apply branch protection rules on dependabot branches
-      - "dependabot/.*"
+      include:
+        - main
+        - master
+        - release-.*
       repos:
         cert-manager:
           branches:


### PR DESCRIPTION
> [!NOTE]
> This problem only occurs to **GitHub "Owners"** (i.e., "Admins" in our governance charter). GitHub Members, Reviewers, Approvers, and Maintainers aren't affected since they are set to "Members" and can't create branches.

I'd like to disable branch protection for branches that aren't main, master, or release-* because I am sick of having to manually disable the branch protection.

Many times, I edit a file using the GitHub UI which mistakenly creates a branch on the project directly. There is no way to configure GitHub so that "Owners" use a fork instead.

I don't think branch protection is the correct way to force "Owners" to use a fork; blocking the creation of branches would work much better. GitHub will probably give us a setting for that in the future, hopefully.

> [!IMPORTANT]
> Disabling branch protection would be a temporary fix until we find a better way of restricting the branch creation for "Owners" (including when using the GitHub UI).

> [!NOTE]
> How did I find about this `include` field? It isn't documented in the [official branchprotector page](https://docs.prow.k8s.io/docs/components/optional/branchprotector/), I had to dig into Prow's [branch_protection.go](https://github.com/kubernetes/test-infra/blob/8af21b17a59c25754711dd382a7eec7cecce8a78/prow/config/branch_protection.go#L59C45-L59C45) to know about that field.

> [!NOTE]
> After doing some "live" tests today (which I reverted afterwards), I have a fairly high confidence in how this new setting (`include`) won't have any negative impact.
> 
> What I did:
> ```bash
> make update-config
> k rollout restart deploy/prow-controller-manager
> sleep 10
> kubectl logs -n default -l app=prow-controller-manager --tail=5
> # No errors.
> ```
> I then got back to the `main` branch and re-applied `make update-config`.
