### PR TITLE
Add release 1.13 tests, milestones and dashboard

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -75,6 +75,13 @@ branch-protection:
                 - pull-cert-manager-release-1.12-make-test
                 - pull-cert-manager-release-1.12-e2e-v1-27
                 - pull-cert-manager-release-1.12-e2e-v1-27-upgrade
+            release-1.13:
+              required_status_checks:
+                contexts:
+                - pull-cert-manager-release-1.13-chart
+                - pull-cert-manager-release-1.13-make-test
+                - pull-cert-manager-release-1.13-e2e-v1-28
+                - pull-cert-manager-release-1.13-e2e-v1-28-upgrade
             master:
               required_status_checks:
                 contexts:

--- a/config/jobs/cert-manager/cert-manager/release-1.13/cert-manager-release-1.13.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.13/cert-manager-release-1.13.yaml
@@ -1,0 +1,1617 @@
+# THIS FILE HAS BEEN AUTOMATICALLY GENERATED
+# Don't manually edit it; instead edit the "prowgen" tool which generated it
+# Generated with: prowgen --branch=* -o cert-manager
+
+presubmits:
+  cert-manager/cert-manager:
+  - name: pull-cert-manager-release-1.13-make-test
+    max_concurrency: 8
+    decorate: true
+    annotations:
+      description: Runs unit and integration tests and verification scripts
+    labels:
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+        args:
+        - runner
+        - make
+        - -j2
+        - vendor-go
+        - ci-presubmit
+        - test-ci
+        resources:
+          requests:
+            cpu: 2000m
+            memory: 4Gi
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - release-1.13
+    always_run: true
+    optional: false
+  - name: pull-cert-manager-release-1.13-chart
+    max_concurrency: 8
+    decorate: true
+    annotations:
+      description: Verifies the Helm chart passes linting checks
+    labels:
+      preset-dind-enabled: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+        args:
+        - runner
+        - make
+        - vendor-go
+        - verify-chart
+        resources:
+          requests:
+            cpu: "1"
+            memory: 1Gi
+        securityContext:
+          privileged: true
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - release-1.13
+    always_run: true
+    optional: false
+  - name: pull-cert-manager-release-1.13-e2e-v1-23
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.23
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - release-1.13
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.13-e2e-v1-24
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.24
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - release-1.13
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.13-e2e-v1-25
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.25 cluster
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.25
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - release-1.13
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.13-e2e-v1-26
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.26 cluster
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.26
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - release-1.13
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.13-e2e-v1-27
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.27 cluster
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.27
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - release-1.13
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.13-e2e-v1-28
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.28 cluster
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.28
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - release-1.13
+    always_run: true
+    optional: false
+  - name: pull-cert-manager-release-1.13-e2e-v1-28-upgrade
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs cert-manager upgrade from latest published release
+    labels:
+      preset-dind-enabled: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+        args:
+        - runner
+        - make
+        - K8S_VERSION=1.28
+        - vendor-go
+        - test-upgrade
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - release-1.13
+    always_run: true
+    optional: false
+  - name: pull-cert-manager-release-1.13-license
+    max_concurrency: 8
+    decorate: true
+    annotations:
+      description: Verifies LICENSES are up to date; only needs to be run if go.mod
+        has changed
+    labels:
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+        args:
+        - runner
+        - make
+        - vendor-go
+        - verify-licenses
+        resources:
+          requests:
+            cpu: "1"
+            memory: 1Gi
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - release-1.13
+    always_run: false
+    optional: true
+    run_if_changed: go.mod
+  - name: pull-cert-manager-release-1.13-e2e-v1-28-issuers-venafi-tpp
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the E2E tests with 'Venafi TPP' in name
+    labels:
+      preset-dind-enabled: "true"
+      preset-ginkgo-focus-venafi-tpp: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-service-account: "true"
+      preset-venafi-tpp-credentials: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.28
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - release-1.13
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.13-e2e-v1-28-issuers-venafi-cloud
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the E2E tests with 'Venafi Cloud' in name
+    labels:
+      preset-dind-enabled: "true"
+      preset-ginkgo-focus-venafi-cloud: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-service-account: "true"
+      preset-venafi-cloud-credentials: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.28
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - release-1.13
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.13-e2e-v1-28-feature-gates-disabled
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.28
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - release-1.13
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.13-e2e-v1-28-bestpractice-install
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the E2E tests with cert-manager installed in accordance with
+        https://cert-manager.io/docs/installation/best-practice/
+    labels:
+      preset-bestpractice-install: "true"
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.28
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+    branches:
+    - release-1.13
+    always_run: false
+    optional: true
+periodics:
+- name: ci-cert-manager-release-1.13-make-test
+  max_concurrency: 8
+  decorate: true
+  annotations:
+    description: Runs unit and integration tests and verification scripts
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+  labels:
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j2
+      - vendor-go
+      - ci-presubmit
+      - test-ci
+      resources:
+        requests:
+          cpu: 2000m
+          memory: 4Gi
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 2h
+- name: ci-cert-manager-release-1.13-e2e-v1-23
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.23
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 2h
+- name: ci-cert-manager-release-1.13-e2e-v1-24
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.24
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 2h
+- name: ci-cert-manager-release-1.13-e2e-v1-25
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.25 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.25
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 2h
+- name: ci-cert-manager-release-1.13-e2e-v1-26
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.26 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.26
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 2h
+- name: ci-cert-manager-release-1.13-e2e-v1-27
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.27 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.27
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 2h
+- name: ci-cert-manager-release-1.13-e2e-v1-28
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.28 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.28
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 2h
+- name: ci-cert-manager-release-1.13-e2e-v1-28-issuers-venafi
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs Venafi (VaaS and TPP) e2e tests
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+  labels:
+    preset-dind-enabled: "true"
+    preset-ginkgo-focus-venafi: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+    preset-venafi-cloud-credentials: "true"
+    preset-venafi-tpp-credentials: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.28
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 12h
+- name: ci-cert-manager-release-1.13-e2e-v1-28-upgrade
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs cert-manager upgrade from latest published release
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+  labels:
+    preset-dind-enabled: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - K8S_VERSION=1.28
+      - vendor-go
+      - test-upgrade
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 8h
+- name: ci-cert-manager-release-1.13-e2e-v1-28-bestpractice-install
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with cert-manager installed in accordance with
+      https://cert-manager.io/docs/installation/best-practice/
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+  labels:
+    preset-bestpractice-install: "true"
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.28
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 24h
+- name: ci-cert-manager-release-1.13-e2e-v1-23-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.23
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 24h
+- name: ci-cert-manager-release-1.13-e2e-v1-24-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.24
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 24h
+- name: ci-cert-manager-release-1.13-e2e-v1-25-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.25
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 24h
+- name: ci-cert-manager-release-1.13-e2e-v1-26-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.26
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 24h
+- name: ci-cert-manager-release-1.13-e2e-v1-27-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.27
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 24h
+- name: ci-cert-manager-release-1.13-e2e-v1-28-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.28
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 24h
+- name: ci-cert-manager-release-1.13-trivy-test-controller
+  max_concurrency: 2
+  decorate: true
+  annotations:
+    description: Runs a Trivy scan against the controller container
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-alert-stale-results-hours: "36"
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+    testgrid-num-failures-to-alert: "1"
+  labels:
+    preset-dind-enabled: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j1
+      - vendor-go
+      - trivy-scan-controller
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+      securityContext:
+        privileged: true
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 24h
+- name: ci-cert-manager-release-1.13-trivy-test-acmesolver
+  max_concurrency: 2
+  decorate: true
+  annotations:
+    description: Runs a Trivy scan against the acmesolver container
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-alert-stale-results-hours: "36"
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+    testgrid-num-failures-to-alert: "1"
+  labels:
+    preset-dind-enabled: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j1
+      - vendor-go
+      - trivy-scan-acmesolver
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+      securityContext:
+        privileged: true
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 24h
+- name: ci-cert-manager-release-1.13-trivy-test-ctl
+  max_concurrency: 2
+  decorate: true
+  annotations:
+    description: Runs a Trivy scan against the ctl container
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-alert-stale-results-hours: "36"
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+    testgrid-num-failures-to-alert: "1"
+  labels:
+    preset-dind-enabled: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j1
+      - vendor-go
+      - trivy-scan-ctl
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+      securityContext:
+        privileged: true
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 24h
+- name: ci-cert-manager-release-1.13-trivy-test-cainjector
+  max_concurrency: 2
+  decorate: true
+  annotations:
+    description: Runs a Trivy scan against the cainjector container
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-alert-stale-results-hours: "36"
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+    testgrid-num-failures-to-alert: "1"
+  labels:
+    preset-dind-enabled: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j1
+      - vendor-go
+      - trivy-scan-cainjector
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+      securityContext:
+        privileged: true
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 24h
+- name: ci-cert-manager-release-1.13-trivy-test-webhook
+  max_concurrency: 2
+  decorate: true
+  annotations:
+    description: Runs a Trivy scan against the webhook container
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-alert-stale-results-hours: "36"
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+    testgrid-num-failures-to-alert: "1"
+  labels:
+    preset-dind-enabled: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20230406-0ef4440-bullseye
+      args:
+      - runner
+      - make
+      - -j1
+      - vendor-go
+      - trivy-scan-webhook
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+      securityContext:
+        privileged: true
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  interval: 24h

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -41,7 +41,8 @@ repo_milestone:
 
 milestone_applier:
   cert-manager/cert-manager:
-    master: v1.13
+    master: v1.14
+    release-1.13: v1.13
     release-1.12: v1.12
     release-1.11: v1.11
     release-1.10: v1.10

--- a/config/prowgen/prowspecs/specs.go
+++ b/config/prowgen/prowspecs/specs.go
@@ -74,6 +74,27 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 		e2eCPURequest:    "7000m",
 		e2eMemoryRequest: "6Gi",
 	},
+	"release-1.13": {
+		prowContext: &pkg.ProwContext{
+			Branch: "release-1.13",
+
+			// Use latest image.
+			Image: pkg.CommonTestImage,
+
+			// NB: we don't use a presubmit dashboard outside of "master", currently
+			PresubmitDashboard: false,
+			PeriodicDashboard:  true,
+
+			Org:  "cert-manager",
+			Repo: "cert-manager",
+		},
+
+		primaryKubernetesVersion: "1.28",
+		otherKubernetesVersions:  []string{"1.23", "1.24", "1.25", "1.26", "1.27"},
+
+		e2eCPURequest:    "7000m",
+		e2eMemoryRequest: "6Gi",
+	},
 	"master": {
 		prowContext: &pkg.ProwContext{
 			Branch: "master",

--- a/config/testgrid/dashboards.yaml
+++ b/config/testgrid/dashboards.yaml
@@ -5,6 +5,7 @@ dashboard_groups:
   - cert-manager-periodics-master
   - cert-manager-periodics-release-1.11
   - cert-manager-periodics-release-1.12
+  - cert-manager-periodics-release-1.13
   - cert-manager-presubmits-master
   - jetstack-testing-janitors
 
@@ -13,5 +14,6 @@ dashboards:
 - name: cert-manager-periodics-master
 - name: cert-manager-periodics-release-1.11
 - name: cert-manager-periodics-release-1.12
+- name: cert-manager-periodics-release-1.13
 - name: cert-manager-presubmits-master
 - name: jetstack-testing-janitors


### PR DESCRIPTION
Before we release 1.13, we should have tests setup on the release-1.13 branch.