### PR TITLE
Switch nodeport services to clusterIP

### DIFF
--- a/prow/cluster/deck_service.yaml
+++ b/prow/cluster/deck_service.yaml
@@ -30,4 +30,3 @@ spec:
   - name: metrics
     port: 9090
     protocol: TCP
-  type: NodePort

--- a/prow/cluster/hook_service.yaml
+++ b/prow/cluster/hook_service.yaml
@@ -31,4 +31,3 @@ spec:
   - name: metrics
     port: 9090
     protocol: TCP
-  type: NodePort

--- a/prow/cluster/needs-rebase_service.yaml
+++ b/prow/cluster/needs-rebase_service.yaml
@@ -23,4 +23,3 @@ spec:
   ports:
   - port: 80
     targetPort: 8888
-  type: NodePort

--- a/prow/cluster/pushgateway_deployment.yaml
+++ b/prow/cluster/pushgateway_deployment.yaml
@@ -36,7 +36,6 @@ spec:
   - name: pushgateway
     port: 80
     targetPort: http
-  type: NodePort
   selector:
     app: pushgateway
 ---
@@ -110,6 +109,5 @@ spec:
   - name: pushgateway-external
     port: 80
     targetPort: http
-  type: NodePort
   selector:
     app: pushgateway-proxy

--- a/prow/cluster/tot_service.yaml
+++ b/prow/cluster/tot_service.yaml
@@ -23,4 +23,3 @@ spec:
   ports:
   - port: 80
     targetPort: 8888
-  type: NodePort


### PR DESCRIPTION
I'm don't know why Kubernetes makes all these services NodePort services, but I don't think we need it.

I applied this config on 20/10/2023 and will report whether we experience any problems.