### PR TITLE
Fix error in autobumper configuration

### DIFF
--- a/config/autobump-config/testing-autobump-config.yaml
+++ b/config/autobump-config/testing-autobump-config.yaml
@@ -4,7 +4,7 @@ gitHubToken: "/etc/github/token"
 gitName: "jetstack-bot"
 gitEmail: "jetstack-bot@users.noreply.github.com"
 skipPullRequest: false
-gitHubOrg: "jetstack"
+gitHubOrg: "cert-manager"
 gitHubRepo: "testing"
 remoteName: "testing"
 headBranchName: "autobump"


### PR DESCRIPTION
This error is caused by our migration from jetstack/testing to cert-manager/testing.
We forgot to update this field in the autobump config.