### PR TITLE
Tweak running test jobs for trust-manager

### DIFF
--- a/config/jobs/cert-manager/trust-manager/trust-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/trust-manager/trust-manager-presubmits.yaml
@@ -39,6 +39,7 @@ presubmits:
     decorate: true
     branches:
     - ^main$
+    - ^release-.*$
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
The smoke test is currently only configured to run against main (manually, in the job spec) and so it won't run (or pass) for the new release-0.6 branch.