### PR TITLE
Bump golang version for testing istio-csr

### DIFF
--- a/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
+++ b/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     - ^main$
     spec:
       containers:
-      - image: golang:1.20
+      - image: golang:1.21
         args:
         - make
         - verify


### PR DESCRIPTION
Prerequisite for https://github.com/cert-manager/istio-csr/pull/219