### PR TITLE
chore(approver-policy): replace golang image with jetstack:golang-dind

### DIFF
--- a/config/jobs/cert-manager/approver-policy/cert-manager-approver-policy-presubmits.yaml
+++ b/config/jobs/cert-manager/approver-policy/cert-manager-approver-policy-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       testgrid-create-test-group: 'false'
     spec:
       containers:
-      - image: golang:1.20
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20231020-a4e175b-1.21.3
         args:
         - make
         - verify
@@ -26,7 +26,7 @@ presubmits:
       testgrid-create-test-group: 'false'
     spec:
       containers:
-      - image: golang:1.20
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20231020-a4e175b-1.21.3
         args:
         - make
         - test


### PR DESCRIPTION
To install `protoc` in https://github.com/cert-manager/approver-policy/pull/277 I need `unzip` available in the CI images. One of the approver-policy CI-jobs (the single one not failing on the PR) already uses the Jetstack golang image, so I think this change can be justified.

/cc @irbekrm 