### PR TITLE
Use latest make-dind images

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -18,7 +18,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -53,7 +53,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -92,7 +92,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -143,7 +143,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -194,7 +194,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -245,7 +245,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -296,7 +296,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -347,7 +347,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -394,7 +394,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -433,7 +433,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -470,7 +470,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -520,7 +520,7 @@ presubmits:
       preset-venafi-cloud-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -571,7 +571,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -624,7 +624,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -671,7 +671,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -711,7 +711,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -763,7 +763,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -815,7 +815,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -867,7 +867,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -919,7 +919,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -971,7 +971,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1023,7 +1023,7 @@ periodics:
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1071,7 +1071,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1117,7 +1117,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1169,7 +1169,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1221,7 +1221,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1273,7 +1273,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1325,7 +1325,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1377,7 +1377,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1429,7 +1429,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1479,7 +1479,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1518,7 +1518,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1557,7 +1557,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1596,7 +1596,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1635,7 +1635,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make

--- a/config/jobs/cert-manager/cert-manager/release-1.12/cert-manager-release-1.12.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.12/cert-manager-release-1.12.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -47,7 +47,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -83,7 +83,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -131,7 +131,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -179,7 +179,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -227,7 +227,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -275,7 +275,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -323,7 +323,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -367,7 +367,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -403,7 +403,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -437,7 +437,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -484,7 +484,7 @@ presubmits:
       preset-venafi-cloud-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -532,7 +532,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -582,7 +582,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -629,7 +629,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -669,7 +669,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -721,7 +721,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -773,7 +773,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -825,7 +825,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -877,7 +877,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -929,7 +929,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -981,7 +981,7 @@ periodics:
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1029,7 +1029,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1075,7 +1075,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1127,7 +1127,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1179,7 +1179,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1231,7 +1231,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1283,7 +1283,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1335,7 +1335,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1387,7 +1387,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1437,7 +1437,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1476,7 +1476,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1515,7 +1515,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1554,7 +1554,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1593,7 +1593,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make

--- a/config/jobs/cert-manager/cert-manager/release-1.13/cert-manager-release-1.13.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.13/cert-manager-release-1.13.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -47,7 +47,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -83,7 +83,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -131,7 +131,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -179,7 +179,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -227,7 +227,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -275,7 +275,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -323,7 +323,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -367,7 +367,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -403,7 +403,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -437,7 +437,7 @@ presubmits:
       preset-venafi-tpp-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -484,7 +484,7 @@ presubmits:
       preset-venafi-cloud-credentials: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -532,7 +532,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -582,7 +582,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
@@ -629,7 +629,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -669,7 +669,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -721,7 +721,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -773,7 +773,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -825,7 +825,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -877,7 +877,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -929,7 +929,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -981,7 +981,7 @@ periodics:
     preset-venafi-tpp-credentials: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1029,7 +1029,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1075,7 +1075,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1127,7 +1127,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1179,7 +1179,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1231,7 +1231,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1283,7 +1283,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1335,7 +1335,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1387,7 +1387,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1437,7 +1437,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1476,7 +1476,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1515,7 +1515,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1554,7 +1554,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make
@@ -1593,7 +1593,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
       args:
       - runner
       - make

--- a/config/prowgen/pkg/globals.go
+++ b/config/prowgen/pkg/globals.go
@@ -19,7 +19,7 @@ package pkg
 
 const (
 	// CommonTestImage defines the common base image used across many prow jobs
-	CommonTestImage = "eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye"
+	CommonTestImage = "eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm"
 
 	// AlertEmailAddress is the address to which testgrid alerts should be sent
 	AlertEmailAddress = "cert-manager-dev-alerts@googlegroups.com"

--- a/images/golang-dind/build.yaml
+++ b/images/golang-dind/build.yaml
@@ -3,11 +3,11 @@ name: golang-dind # Name of the image to be built
 variants:
   "1.21":
     arguments:
-      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye"
+      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm"
       GO_VERSION: "1.21.3"
   "1.20":
     arguments:
-      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/make-dind:20231114-2f36f6c-bullseye"
+      BASE_IMAGE: "eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm"
       GO_VERSION: "1.20.10"
   "1.19":
     arguments:


### PR DESCRIPTION
Use new debian 12 make-dind image.

see https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/logs/ci-cert-manager-master-e2e-v1-23/1724781156580200448 for a successful e2e test that was run using this image (this image also fixes the buildx problem).