### PR TITLE
Re-add use of iptables-legacy

### DIFF
--- a/images/make-dind/Dockerfile
+++ b/images/make-dind/Dockerfile
@@ -68,7 +68,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         docker-ce="${DOCKER_VERSION}" \
     && apt-get clean \
-    && sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker
+    && sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker \
+    && update-alternatives --set iptables /usr/sbin/iptables-legacy \
+    && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 
 # Move Docker's storage location & add Container Registry cache (see: https://cloud.google.com/container-registry/docs/pulling-cached-images)
 # @inteon: added --mtu 1460 to fix network issues due to parent mtu < child mtu (see https://blog.zespre.com/dind-mtu-size-matters.html)


### PR DESCRIPTION
This PR re-adds the use of iptables-legacy. In https://github.com/cert-manager/testing/pull/927, I removed this workaround because I thought it wasn't used anymore.

Turns out that removing this results in the following error:
```
failed to start daemon: Error initializing network controller: error obtaining controller instance: unable to add return rule in DOCKER-ISOLATION-STAGE-1 chain:  (iptables failed: iptables --wait -A DOCKER-ISOLATION-STAGE-1 -j RETURN: iptables v1.8.9 (nf_tables):  RULE_APPEND failed (No such file or directory): rule in chain DOCKER-ISOLATION-STAGE-1
 (exit status 4))
```