### PR TITLE
Re-add docker buildx

### DIFF
--- a/images/make-dind/Dockerfile
+++ b/images/make-dind/Dockerfile
@@ -67,6 +67,7 @@ ARG DOCKER_VERSION
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         docker-ce="${DOCKER_VERSION}" \
+        docker-buildx-plugin \
     && apt-get clean \
     && sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker \
     && update-alternatives --set iptables /usr/sbin/iptables-legacy \


### PR DESCRIPTION
It seems like we still have to additionally install buildx. Otherwise we get the following error:
```
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/
```
I tried to remove this line in https://github.com/cert-manager/testing/pull/927