### PR TITLE
fix incorrect use of annotations instead of labels

### DIFF
--- a/config/jobs/cert-manager/approver-policy/cert-manager-approver-policy-presubmits.yaml
+++ b/config/jobs/cert-manager/approver-policy/cert-manager-approver-policy-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
     decorate: true
     always_run: true
     max_concurrency: 8
-    annotations:
+    labels:
       preset-go-cache: "true"
       preset-local-cache: "true"
     spec:
@@ -25,7 +25,7 @@ presubmits:
     decorate: true
     always_run: true
     max_concurrency: 8
-    annotations:
+    labels:
       preset-go-cache: "true"
       preset-local-cache: "true"
     spec:


### PR DESCRIPTION
In https://github.com/cert-manager/testing/pull/934, I incorrectly set some of the templates as `annotations` instead of `labels`.
This PR fixes the error.