### PR TITLE
Fix bug that causes caching to fail

### DIFF
--- a/images/make-dind/runner
+++ b/images/make-dind/runner
@@ -34,7 +34,7 @@ if [[ "${LOCAL_CACHE_ENABLED}" == "true" ]]; then
     fi
 
     # Convert local cache directory to absolute path and re-export it.
-    LOCAL_CACHE_DIR="$(PWD)/${LOCAL_CACHE_DIR}"
+    LOCAL_CACHE_DIR="$(pwd)/${LOCAL_CACHE_DIR}"
     export LOCAL_CACHE_DIR
 
     if [[ -f "${SHARED_CACHE_DIR}/latest" ]]; then


### PR DESCRIPTION
Typo should have been `$(pwd)` instead of `$(PWD)`.

example: https://prow.build-infra.jetstack.net/log?container=test&id=1742895913195540480&job=pull-cert-manager-master-e2e-v1-28

```
/usr/local/bin/runner: line 37: PWD: command not found
```
