### PR TITLE
istio-csr: Use new test target names (part of migration to makefile-modules)

### DIFF
--- a/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
+++ b/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
@@ -4,17 +4,36 @@ presubmits:
   - name: pull-cert-manager-istio-csr-verify
     decorate: true
     always_run: true
-    max_concurrency: 8
-    annotations:
-      testgrid-create-test-group: 'false'
-    branches:
-    - ^main$
+    labels:
+      preset-go-cache: "true"
+      preset-local-cache: "true"
     spec:
       containers:
-      - image: golang:1.21
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
+        - runner
         - make
+        - vendor-go
         - verify
+        resources:
+          requests:
+            cpu: 1
+            memory: 1Gi
+
+  - name: pull-cert-manager-istio-csr-unit
+    decorate: true
+    always_run: true
+    labels:
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
+        args:
+        - runner
+        - make
+        - vendor-go
+        - test-unit
         resources:
           requests:
             cpu: 1
@@ -23,18 +42,19 @@ presubmits:
   - name: pull-cert-manager-istio-csr-ca-rotation
     decorate: true
     always_run: true
-    branches:
-    - ^main$
     labels:
+      preset-go-cache: "true"
+      preset-local-cache: "true"
       preset-service-account: "true"
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20231115-6d9432b-1.21.3
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
-        - carotation
+        - vendor-go
+        - test-carotation
         resources:
           requests:
             cpu: 3500m
@@ -50,22 +70,21 @@ presubmits:
 
   # kind based istio-csr e2e job for Kubernetes v1.26, istio v1.14
   - name: pull-cert-manager-istio-csr-k8s-v1-26-istio-v1-14
-    always_run: true
-    optional: false
-    max_concurrency: 8
     decorate: true
-    branches:
-    - ^main$
+    always_run: true
     labels:
+      preset-go-cache: "true"
+      preset-local-cache: "true"
       preset-service-account: "true"
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20231115-6d9432b-1.21.3
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
-        - e2e
+        - vendor-go
+        - test-e2e
         resources:
           requests:
             cpu: 3500m
@@ -86,22 +105,21 @@ presubmits:
 
   # kind based istio-csr e2e job for Kubernetes v1.26, istio v1.15
   - name: pull-cert-manager-istio-csr-k8s-v1-26-istio-v1-15
-    always_run: true
-    optional: false
-    max_concurrency: 8
     decorate: true
-    branches:
-    - ^main$
+    always_run: true
     labels:
+      preset-go-cache: "true"
+      preset-local-cache: "true"
       preset-service-account: "true"
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20231115-6d9432b-1.21.3
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
-        - e2e
+        - vendor-go
+        - test-e2e
         resources:
           requests:
             cpu: 3500m
@@ -122,22 +140,21 @@ presubmits:
 
   # kind based istio-csr e2e job for Kubernetes v1.26, istio v1.16
   - name: pull-cert-manager-istio-csr-k8s-v1-26-istio-v1-16
-    always_run: true
-    optional: false
-    max_concurrency: 8
     decorate: true
-    branches:
-    - ^main$
+    always_run: true
     labels:
+      preset-go-cache: "true"
+      preset-local-cache: "true"
       preset-service-account: "true"
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20231115-6d9432b-1.21.3
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
-        - e2e
+        - vendor-go
+        - test-e2e
         resources:
           requests:
             cpu: 3500m
@@ -158,22 +175,21 @@ presubmits:
 
   # kind based istio-csr e2e job for Kubernetes v1.26, istio v1.17
   - name: pull-cert-manager-istio-csr-k8s-v1-26-istio-v1-17
-    always_run: true
-    optional: false
-    max_concurrency: 8
     decorate: true
-    branches:
-    - ^main$
+    always_run: true
     labels:
+      preset-go-cache: "true"
+      preset-local-cache: "true"
       preset-service-account: "true"
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20231115-6d9432b-1.21.3
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20231115-8c0910c-bookworm
         args:
         - runner
         - make
-        - e2e
+        - vendor-go
+        - test-e2e
         resources:
           requests:
             cpu: 3500m


### PR DESCRIPTION
Once we merge this PR, the tests on https://github.com/cert-manager/istio-csr/pull/221 should start succeeding and it should be ready to be merged.