### PR TITLE
Cleanup approver-policy prowjob yaml

### DIFF
--- a/config/jobs/cert-manager/approver-policy/cert-manager-approver-policy-presubmits.yaml
+++ b/config/jobs/cert-manager/approver-policy/cert-manager-approver-policy-presubmits.yaml
@@ -4,7 +4,6 @@ presubmits:
   - name: pull-cert-manager-approver-policy-verify
     decorate: true
     always_run: true
-    max_concurrency: 8
     labels:
       preset-go-cache: "true"
       preset-local-cache: "true"
@@ -24,7 +23,6 @@ presubmits:
   - name: pull-cert-manager-approver-policy-test
     decorate: true
     always_run: true
-    max_concurrency: 8
     labels:
       preset-go-cache: "true"
       preset-local-cache: "true"
@@ -45,10 +43,10 @@ presubmits:
     decorate: true
     always_run: true
     labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
       preset-go-cache: "true"
       preset-local-cache: "true"
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
     spec:
       containers:
       - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20240104-683c03b-bookworm


### PR DESCRIPTION
Removes `max_concurrency: 8` which was just copied blindly from existing prowjobs afaik.
Also reorders labels to match order of other configs in file.