### PR TITLE
Add tests for the cmctl repo

### DIFF
--- a/config/jobs/cert-manager/cmctl/cert-manager-cmctl.yaml
+++ b/config/jobs/cert-manager/cmctl/cert-manager-cmctl.yaml
@@ -1,0 +1,59 @@
+presubmits:
+  cert-manager/cmctl:
+
+  - name: pull-cert-manager-cmctl-verify
+    decorate: true
+    always_run: true
+    labels:
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20240108-f7d6331-bookworm
+        args:
+        - runner
+        - make
+        - vendor-go
+        - verify
+        resources:
+          requests:
+            cpu: 1
+            memory: 1Gi
+
+  - name: pull-cert-manager-cmctl-test
+    decorate: true
+    always_run: true
+    labels:
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20240108-f7d6331-bookworm
+        args:
+        - runner
+        - make
+        - vendor-go
+        - test-unit
+        resources:
+          requests:
+            cpu: 1
+            memory: 1Gi
+
+  - name: pull-cert-manager-cmctl-integration
+    decorate: true
+    always_run: true
+    labels:
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20240108-f7d6331-bookworm
+        args:
+        - runner
+        - make
+        - vendor-go
+        - test-integration
+        resources:
+          requests:
+            cpu: 1
+            memory: 1Gi

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -10,6 +10,7 @@ triggers:
   - cert-manager/trust-manager
   - cert-manager/issuer-lib
   - cert-manager/helm-tool
+  - cert-manager/cmctl
   only_org_members: true
 
 blunderbuss:


### PR DESCRIPTION
Adds the new github.com/cert-manager/cmctl repo to our tests.