### PR TITLE
Replace the trivy tests for the ctl image

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -1695,11 +1695,11 @@ periodics:
     repo: cert-manager
     base_ref: master
   interval: 24h
-- name: ci-cert-manager-master-trivy-test-ctl
+- name: ci-cert-manager-master-trivy-test-startupapicheck
   max_concurrency: 2
   decorate: true
   annotations:
-    description: Runs a Trivy scan against the ctl container
+    description: Runs a Trivy scan against the startupapicheck container
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-alert-stale-results-hours: "36"
     testgrid-create-job-group: "true"
@@ -1718,7 +1718,7 @@ periodics:
       - make
       - -j1
       - vendor-go
-      - trivy-scan-ctl
+      - trivy-scan-startupapicheck
       resources:
         requests:
           cpu: 1000m

--- a/config/jobs/cert-manager/cert-manager/release-1.14/cert-manager-release-1.14.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.14/cert-manager-release-1.14.yaml
@@ -1537,6 +1537,45 @@ periodics:
     repo: cert-manager
     base_ref: release-1.14
   interval: 24h
+- name: ci-cert-manager-release-1.14-trivy-test-startupapicheck
+  max_concurrency: 2
+  decorate: true
+  annotations:
+    description: Runs a Trivy scan against the startupapicheck container
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-alert-stale-results-hours: "36"
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.14
+    testgrid-num-failures-to-alert: "1"
+  labels:
+    preset-dind-enabled: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20240108-f7d6331-bookworm
+      args:
+      - runner
+      - make
+      - -j1
+      - vendor-go
+      - trivy-scan-startupapicheck
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+      securityContext:
+        privileged: true
+    dnsConfig:
+      options:
+      - name: ndots
+        value: "1"
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.14
+  interval: 24h
 - name: ci-cert-manager-release-1.14-trivy-test-cainjector
   max_concurrency: 2
   decorate: true


### PR DESCRIPTION
Replace them with tests for startupapicheck in the newer releases.