### PR TITLE
Disable branch protection for private repo cert-manager/api

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -61,6 +61,8 @@ branch-protection:
         - master
         - release-.*
       repos:
+        api:
+          protect: false
         cert-manager:
           branches:
             # cert-manager/cert-manager defines required_status_checks on a per


### PR DESCRIPTION
Branch protection can only be enabled on private repos when you have GitHub Pro.
Since we are not yet 100% confident that we will solve cert-manager's API package using a cert-manager/api, I would like to keep the (still empty) repo private.

Fixes the following error:
`
update cert-manager: update api: update main from protected=false: get current branch protection: the GitHub API request returns a 403 error: {\"message\":\"Upgrade to GitHub Pro or make this repository public to enable this feature.\",\"documentation_url\":\"https://docs.github.com/rest/branches/branch-protection#get-branch-protection\"}
`