### PR TITLE
Bump golang images for various components

### DIFF
--- a/config/jobs/cert-manager/boilersuite/cert-manager-boilersuite.yaml
+++ b/config/jobs/cert-manager/boilersuite/cert-manager-boilersuite.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20240108-a2a42cb-1.21.3
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20240308-20aab84-1.22.1
         args:
         - runner
         - make

--- a/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
+++ b/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20240108-a2a42cb-1.21.3
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20240308-20aab84-1.22.1
         args:
         - runner
         - make

--- a/config/jobs/cert-manager/trust-manager/trust-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/trust-manager/trust-manager-presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20240108-a2a42cb-1.21.3
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20240308-20aab84-1.22.1
         args:
         - runner
         - make
@@ -45,7 +45,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20240108-a2a42cb-1.21.3
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20240308-20aab84-1.22.1
         args:
         - runner
         - make

--- a/config/jobs/testing/testing-postsubmits-trusted.yaml
+++ b/config/jobs/testing/testing-postsubmits-trusted.yaml
@@ -232,7 +232,9 @@ postsubmits:
       description: Build and push the 'kind' image
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind@sha256:ac1c44a3bb2781258e570a9e2ec25b3a8464a8112f46703b1769510940612344
+      # TODO: why is this a digest in contrast to everything else?
+      # eu.gcr.io/jetstack-build-infra-images/golang-dind:20240308-20aab84-1.21.8
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind@sha256:cda16346a368732a7a95c54750e01f8df6af6230e35d7c95e982ee9c53c26f5a
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner

--- a/config/jobs/testing/testing-presubmits.yaml
+++ b/config/jobs/testing/testing-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20240108-a2a42cb-1.21.3
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20240308-20aab84-1.21.8
         args:
         - runner
         - make
@@ -47,7 +47,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20240108-a2a42cb-1.21.3
+      - image: eu.gcr.io/jetstack-build-infra-images/golang-dind:20240308-20aab84-1.21.8
         args:
         - runner
         - make


### PR DESCRIPTION
The key is bumping the trust-manager images to 1.22.x but it seemed sane to also bump boilersuite and the release tool to 1.22

I left some others on 1.21.x to minimise changes there, and I used a digest for the kind image to minimise what I changed here.