### PR TITLE
fix image typo

### DIFF
--- a/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
+++ b/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
@@ -282,7 +282,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: eu.gcr.io/jetstack-build-infra-images/make-dind20240308-a6a8aa9-bookworm
+      - image: eu.gcr.io/jetstack-build-infra-images/make-dind:20240308-a6a8aa9-bookworm
         args:
         - runner
         - make


### PR DESCRIPTION
Fixes typo introduced in https://github.com/cert-manager/testing/pull/973