### PR TITLE
Use correct url for new infra image repository

### DIFF
--- a/images/builder/README.md
+++ b/images/builder/README.md
@@ -43,7 +43,7 @@ them available for templating in the `images` section of the `build.yaml` file.
 | Name        | Description                                          | Example                             |
 +-------------+------------------------------------------------------+-------------------------------------+
 | _NAME       | The name of the image as specified in build.yaml     | bazelbuild                          |
-| _REGISTRY   | The image registry (specified as --registry)         | eu.gcr.io/cert-manager-infra-images |
+| _REGISTRY   | The image registry (specified as --registry)         | europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images |
 | _DATE_STAMP | The current date stamp, useful for use in image tags | 20190407                            |
 | _GIT_REF    | The current git reference of the repository          | 2ba5d19                             |
 | _VARIANT    | The name of the variant being built, if any          | experimental                        |

--- a/images/builder/ci-runner.sh
+++ b/images/builder/ci-runner.sh
@@ -31,7 +31,7 @@ echo "Activating service account..."
 gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
 
 echo "Generating docker credentials..."
-gcloud auth configure-docker --quiet
+gcloud auth configure-docker europe-west1-docker.pkg.dev --quiet
 
 echo "Executing builder..."
 PUSHED_IMAGE=$(bazel run \

--- a/images/builder/main.go
+++ b/images/builder/main.go
@@ -49,7 +49,7 @@ var (
 
 func init() {
 	flag.BoolVar(&confirm, "confirm", false, "set to true to confirm pushing images")
-	flag.StringVar(&registry, "registry", "eu.gcr.io/cert-manager-infra-images", "docker image registry to push images to")
+	flag.StringVar(&registry, "registry", "europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images", "docker image registry to push images to")
 	flag.StringVar(&buildDir, "build-dir", "", "path to a directory containing a build.yaml file")
 	flag.StringVar(&variantName, "variant", "", "if specified, only the given variant will be built")
 }

--- a/images/image-builder-script/README.md
+++ b/images/image-builder-script/README.md
@@ -43,7 +43,7 @@ them available for templating in the `images` section of the `build.yaml` file.
 | Name        | Description                                          | Example                             |
 +-------------+------------------------------------------------------+-------------------------------------+
 | _NAME       | The name of the image as specified in build.yaml     | bazelbuild                          |
-| _REGISTRY   | The image registry (specified as --registry)         | eu.gcr.io/cert-manager-infra-images |
+| _REGISTRY   | The image registry (specified as --registry)         | europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images |
 | _DATE_STAMP | The current date stamp, useful for use in image tags | 20190407                            |
 | _GIT_REF    | The current git reference of the repository          | 2ba5d19                             |
 | _VARIANT    | The name of the variant being built, if any          | experimental                        |

--- a/images/image-builder-script/builder.sh
+++ b/images/image-builder-script/builder.sh
@@ -35,7 +35,7 @@ if [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
     gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
 
     echo "Generating docker credentials..."
-    gcloud auth configure-docker --quiet
+    gcloud auth configure-docker europe-west1-docker.pkg.dev --quiet
 else
     echo "WARNING: GOOGLE_APPLICATION_CREDENTIALS not set"
 fi

--- a/images/image-builder-script/main.go
+++ b/images/image-builder-script/main.go
@@ -48,7 +48,7 @@ var (
 
 func init() {
 	flag.BoolVar(&confirm, "confirm", false, "set to true to confirm pushing images")
-	flag.StringVar(&registry, "registry", "eu.gcr.io/cert-manager-infra-images", "docker image registry to push images to")
+	flag.StringVar(&registry, "registry", "europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images", "docker image registry to push images to")
 	flag.StringVar(&buildDir, "build-dir", "", "path to a directory containing a build.yaml file")
 	flag.StringVar(&variantName, "variant", "", "if specified, only the given variant will be built")
 }

--- a/images/kind/build.sh
+++ b/images/kind/build.sh
@@ -47,7 +47,7 @@ echo "Activating service account..."
 gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
 
 echo "Generating docker credentials..."
-gcloud auth configure-docker --quiet
+gcloud auth configure-docker europe-west1-docker.pkg.dev --quiet
 
 echo "Pushing ${image_tag}..."
 docker push ${image_tag}


### PR DESCRIPTION
Google artifact registry uses a different image url format.