### PR TITLE
Don't fix the go patch version

### DIFF
--- a/config/jobs/cert-manager/boilersuite/cert-manager-boilersuite.yaml
+++ b/config/jobs/cert-manager/boilersuite/cert-manager-boilersuite.yaml
@@ -9,7 +9,7 @@ presubmits:
     labels:
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240416-5ccb4a8-1.22.1
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240416-5ccb4a8-1.22
         args:
         - runner
         - make

--- a/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
+++ b/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     labels:
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240416-5ccb4a8-1.22.1
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240416-5ccb4a8-1.22
         args:
         - runner
         - make

--- a/config/jobs/cert-manager/trust-manager/trust-manager-presubmits.yaml
+++ b/config/jobs/cert-manager/trust-manager/trust-manager-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240416-5ccb4a8-1.22.1
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240416-5ccb4a8-1.22
         args:
         - runner
         - make
@@ -43,7 +43,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240416-5ccb4a8-1.22.1
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240416-5ccb4a8-1.22
         args:
         - runner
         - make

--- a/config/jobs/testing/testing-postsubmits-trusted.yaml
+++ b/config/jobs/testing/testing-postsubmits-trusted.yaml
@@ -162,7 +162,7 @@ postsubmits:
       description: Build and push the 'kind' image
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240416-5ccb4a8-1.22.1
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240416-5ccb4a8-1.22
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner

--- a/config/jobs/testing/testing-presubmits.yaml
+++ b/config/jobs/testing/testing-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240416-5ccb4a8-1.22.1
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240416-5ccb4a8-1.22
         args:
         - runner
         - make
@@ -47,7 +47,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240416-5ccb4a8-1.22.1
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240416-5ccb4a8-1.22
         args:
         - runner
         - make

--- a/images/image-builder/build.yaml
+++ b/images/image-builder/build.yaml
@@ -3,7 +3,7 @@ name: image-builder # Name of the image to be built
 variants:
   gcloud-425:
     arguments:
-      BASE_IMAGE: "europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240416-5ccb4a8-1.22.1"
+      BASE_IMAGE: "europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240416-5ccb4a8-1.22"
       CLOUD_SDK_VERSION: "425.0.0"
 
 # Image names to be tagged and pushed


### PR DESCRIPTION
This will make the autobump job automatically upgrade all go images to the latest built patch version.
eg. 20240416-5ccb4a8-1.22.1 won't get auto-upgraded to 20240416-63d3df9-1.22.2
however, 20240416-5ccb4a8-1.22 does get auto-upgraded to 20240416-63d3df9-1.22