### PR TITLE
Fix failing cherrypicker deployment

### DIFF
--- a/config/jobs/testing/testing-presets-trusted.yaml
+++ b/config/jobs/testing/testing-presets-trusted.yaml
@@ -15,6 +15,7 @@ presets:
   volumeMounts:
   - name: github-token
     mountPath: /etc/github
+    readOnly: true
   volumes:
   - name: github-token
     secret:
@@ -25,6 +26,7 @@ presets:
   volumeMounts:
   - name: ssh
     mountPath: /root/.ssh
+    readOnly: true
   volumes:
   - name: ssh
     secret:
@@ -37,8 +39,9 @@ presets:
   - name: GOOGLE_APPLICATION_CREDENTIALS
     value: /creds/service-account.json
   volumeMounts:
-    - name: creds
-      mountPath: /creds
+  - name: creds
+    mountPath: /creds
+    readOnly: true
   volumes:
   - name: creds
     secret:

--- a/prow/cluster/cherrypicker_deployment.yaml
+++ b/prow/cluster/cherrypicker_deployment.yaml
@@ -42,17 +42,11 @@ spec:
         image: gcr.io/k8s-prow/cherrypicker:v20240415-7013691e3
         imagePullPolicy: Always
         args:
-        - --github-app-id=$(GITHUB_APP_ID)
-        - --github-app-private-key-path=/etc/github/cert
+        - --github-token-path=/etc/github/token
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --dry-run=false
-        env:
-        - name: GITHUB_APP_ID
-          valueFrom:
-            secretKeyRef:
-              name: github-app-token
-              key: appid
+        - --hmac-secret-file=/etc/webhook/hmac
         ports:
           - name: http
             containerPort: 8888
@@ -60,7 +54,7 @@ spec:
         - name: hmac
           mountPath: /etc/webhook
           readOnly: true
-        - name: github-app-token
+        - name: github-token
           mountPath: /etc/github
           readOnly: true
         - name: tmp
@@ -71,6 +65,12 @@ spec:
       - name: hmac
         secret:
           secretName: hmac-token
+      # We cannot use the GitHub APP here because
+      # an APP does not have any repos, and can thus not
+      # have/ create a fork of a repo to create a cherrypick.
       - name: github-app-token
         secret:
           secretName: github-app-token
+      - name: github-token
+        secret:
+          secretName: cert-manager-bot-github-token

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -48,6 +48,7 @@ spec:
         - --github-app-private-key-path=/etc/github/cert
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
+        - --hmac-secret-file=/etc/webhook/hmac
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -41,6 +41,7 @@ spec:
         - --github-app-id=$(GITHUB_APP_ID)
         - --github-app-private-key-path=/etc/github/cert
         - --update-period=6h
+        - --hmac-secret-file=/etc/webhook/hmac
         env:
         - name: GITHUB_APP_ID
           valueFrom:


### PR DESCRIPTION
While that cherrypicker accepts a GH app token as authentication, it doesn't work properly.
Logically, it makes sense that the GH app does not work: the cherrypicker has to create a fork to create the cherrypick PR and thus needs to be able to create a fork (which is something a GH app cannot do).