### PR TITLE
Use the new gencred image to automatically create the worker clusters' kubeconfigs

### DIFF
--- a/config/gencred-config/gencred-config.yaml
+++ b/config/gencred-config/gencred-config.yaml
@@ -1,10 +1,14 @@
 clusters:
 - gke: projects/cert-manager-tests-trusted/locations/europe-west1-b/clusters/prow-trusted
   name: prow-trusted
-  duration: 48h
-  output: kubeconfig.yaml
+  duration: 3h
+  kubernetesSecret:
+    name: kubeconfig-prow-trusted
+    namespace: default
 
 - gke: projects/cert-manager-tests-untrusted/locations/europe-west1-b/clusters/prow-untrusted
   name: default
-  duration: 48h
-  output: kubeconfig.yaml
+  duration: 3h
+  kubernetesSecret:
+    name: kubeconfig-prow-untrusted
+    namespace: default

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -79,6 +79,8 @@ config_updater:
       name: plugins
     config/jobs/**/*.yaml:
       name: job-config
+    config/gencred-config/gencred-config.yaml:
+      name: gencred-config
 
 require_matching_label:
 - missing_label: needs-kind

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -24,22 +24,10 @@ help:
 	@echo "  diff-prow: diff the current prow deployment against the desired state"
 	@echo "  deploy-prow: deploy the prow deployment"
 
-.PHONY: diff-config
-diff-config:
-	cd ../config/ && \
-	kubectl create configmap config --from-file=config.yaml=config.yaml --dry-run=client -o yaml | kubectl diff -f -
-
 # This target allows you to manually update the configmap for the prow config,
 # normally this is done through GitOps.
-.PHONY: update-config
-update-config:
-	cd ../config/ && \
-	kubectl create configmap config --from-file=config.yaml=config.yaml --dry-run=client -o yaml | kubectl replace configmap config -f -
-
-# This target allows you to manually update the configmap for the prow config,
-# normally this is done through GitOps.
-.PHONY: bootstrap-job-config
-bootstrap-job-config:
+.PHONY: bootstrap-config
+bootstrap-config:
 	cd ../ && \
 	go run sigs.k8s.io/prow/prow/cmd/config-bootstrapper@v0.0.0-20240415223539-7013691e3f35 \
 		--dry-run=false \
@@ -47,18 +35,6 @@ bootstrap-job-config:
 		--config-path=config/config.yaml \
 		--plugin-config=config/plugins.yaml \
 		--job-config-path=config/jobs
-
-.PHONY: diff-plugins
-diff-plugins:
-	cd ../config/ && \
-	kubectl create configmap plugins --from-file=plugins.yaml=plugins.yaml --dry-run=client -o yaml | kubectl diff -f -
-
-# This target allows you to manually update the configmap for the prow plugins,
-# normally this is done through GitOps.
-.PHONY: update-plugins
-update-plugins:
-	cd ../config/ && \
-	kubectl create configmap plugins --from-file=plugins.yaml=plugins.yaml --dry-run=client -o yaml | kubectl replace configmap plugins -f -
 
 .PHONY: diff-prow
 diff-prow:
@@ -68,12 +44,3 @@ diff-prow:
 deploy-prow:
 	kubectl apply --server-side -f ./cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
 	kubectl apply --server-side -f ./cluster/
-
-.PHONY: diff-worker
-diff-worker:
-	kubectl diff -f ./worker_cluster/
-
-.PHONY: deploy-worker
-deploy-worker:
-	kubectl create ns test-pods --dry-run=client -o yaml | kubectl apply --server-side -f -
-	kubectl apply --server-side -f ./worker_cluster/

--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config"
+          value: "/etc/kubeconfig-default/config:/etc/kubeconfig-prow-trusted/config"
         - name: GITHUB_APP_ID
           valueFrom:
             secretKeyRef:
@@ -58,8 +58,11 @@ spec:
         - name: metrics
           containerPort: 9090
         volumeMounts:
-        - mountPath: /etc/kubeconfig
-          name: kubeconfig
+        - mountPath: /etc/kubeconfig-prow-trusted
+          name: kubeconfig-prow-trusted
+          readOnly: true
+        - mountPath: /etc/kubeconfig-default
+          name: kubeconfig-prow-untrusted
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -86,7 +89,11 @@ spec:
       - name: gcs-credentials
         secret:
           secretName: gcs-credentials
-      - name: kubeconfig
+      - name: kubeconfig-prow-trusted
         secret:
           defaultMode: 420
-          secretName: kubeconfig
+          secretName: kubeconfig-prow-trusted
+      - name: kubeconfig-prow-untrusted
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-prow-untrusted

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -64,7 +64,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config"
+          value: "/etc/kubeconfig-default/config:/etc/kubeconfig-prow-trusted/config"
         - name: GITHUB_APP_ID
           valueFrom:
             secretKeyRef:
@@ -77,8 +77,11 @@ spec:
         - name: cookie-secret
           mountPath: /etc/cookie
           readOnly: true
-        - mountPath: /etc/kubeconfig
-          name: kubeconfig
+        - mountPath: /etc/kubeconfig-prow-trusted
+          name: kubeconfig-prow-trusted
+          readOnly: true
+        - mountPath: /etc/kubeconfig-default
+          name: kubeconfig-prow-untrusted
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -115,10 +118,14 @@ spec:
       - name: cookie-secret
         secret:
           secretName: cookie
-      - name: kubeconfig
+      - name: kubeconfig-prow-trusted
         secret:
           defaultMode: 420
-          secretName: kubeconfig
+          secretName: kubeconfig-prow-trusted
+      - name: kubeconfig-prow-untrusted
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-prow-untrusted
       - name: config
         configMap:
           name: config

--- a/prow/cluster/gencred_deployment.yaml
+++ b/prow/cluster/gencred_deployment.yaml
@@ -1,0 +1,55 @@
+# Copyright 2019 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This deployment is a customization on top of the "default" prow setup
+# to avoid the use of long-lived manually-managed kubeconfig secrets,
+# we instead use the gencred tool to authenticate to GCP and retrieve
+# the kubeconfigs that we need to run the prowjobs in other clusters.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: gencred
+  labels:
+    app: gencred
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gencred
+  template:
+    metadata:
+      labels:
+        app: gencred
+    spec:
+      serviceAccountName: gencred
+      terminationGracePeriodSeconds: 30
+      containers:
+      - name: gencred
+        image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/gencred:20240417-d0e6803
+        args:
+        - --config=/etc/config/gencred-config.yaml
+        - --refresh-interval=2h
+        ports:
+        - name: metrics
+          containerPort: 9090
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: gencred-config

--- a/prow/cluster/gencred_rbac.yaml
+++ b/prow/cluster/gencred_rbac.yaml
@@ -1,0 +1,49 @@
+# Copyright 2019 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: gencred
+  namespace: default
+  annotations:
+    iam.gke.io/gcp-service-account: prow-gencred@cert-manager-tests-trusted.iam.gserviceaccount.com
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: default
+  name: gencred
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - "secrets"
+  verbs:
+    - "patch"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gencred-namespaced
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gencred
+subjects:
+- kind: ServiceAccount
+  name: gencred
+  namespace: default

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -52,7 +52,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config"
+          value: "/etc/kubeconfig-default/config:/etc/kubeconfig-prow-trusted/config"
         - name: GITHUB_APP_ID
           valueFrom:
             secretKeyRef:
@@ -79,8 +79,11 @@ spec:
         - name: plugins
           mountPath: /etc/plugins
           readOnly: true
-        - name: kubeconfig
-          mountPath: /etc/kubeconfig
+        - mountPath: /etc/kubeconfig-prow-trusted
+          name: kubeconfig-prow-trusted
+          readOnly: true
+        - mountPath: /etc/kubeconfig-default
+          name: kubeconfig-prow-untrusted
           readOnly: true
         livenessProbe:
           httpGet:
@@ -111,7 +114,11 @@ spec:
       - name: plugins
         configMap:
           name: plugins
-      - name: kubeconfig
+      - name: kubeconfig-prow-trusted
         secret:
           defaultMode: 420
-          secretName: kubeconfig
+          secretName: kubeconfig-prow-trusted
+      - name: kubeconfig-prow-untrusted
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-prow-untrusted

--- a/prow/cluster/prow_controller_manager_deployment.yaml
+++ b/prow/cluster/prow_controller_manager_deployment.yaml
@@ -48,13 +48,16 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config"
+          value: "/etc/kubeconfig-default/config:/etc/kubeconfig-prow-trusted/config"
         ports:
         - name: metrics
           containerPort: 9090
         volumeMounts:
-        - mountPath: /etc/kubeconfig
-          name: kubeconfig
+        - mountPath: /etc/kubeconfig-prow-trusted
+          name: kubeconfig-prow-trusted
+          readOnly: true
+        - mountPath: /etc/kubeconfig-default
+          name: kubeconfig-prow-untrusted
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -75,10 +78,14 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 3
       volumes:
-      - name: kubeconfig
+      - name: kubeconfig-prow-trusted
         secret:
           defaultMode: 420
-          secretName: kubeconfig
+          secretName: kubeconfig-prow-trusted
+      - name: kubeconfig-prow-untrusted
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-prow-untrusted
       - name: config
         configMap:
           name: config

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -26,13 +26,16 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config"
+          value: "/etc/kubeconfig-default/config:/etc/kubeconfig-prow-trusted/config"
         ports:
         - name: metrics
           containerPort: 9090
         volumeMounts:
-        - mountPath: /etc/kubeconfig
-          name: kubeconfig
+        - mountPath: /etc/kubeconfig-prow-trusted
+          name: kubeconfig-prow-trusted
+          readOnly: true
+        - mountPath: /etc/kubeconfig-default
+          name: kubeconfig-prow-untrusted
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -41,10 +44,14 @@ spec:
           mountPath: /etc/job-config
           readOnly: true
       volumes:
-      - name: kubeconfig
+      - name: kubeconfig-prow-trusted
         secret:
           defaultMode: 420
-          secretName: kubeconfig
+          secretName: kubeconfig-prow-trusted
+      - name: kubeconfig-prow-untrusted
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-prow-untrusted
       - name: config
         configMap:
           name: config


### PR DESCRIPTION
Adds a gencred deployment that dynamically generates the worker clusters' kubeconfig secrets.