### PR TITLE
Optimise make-dind image

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -10,7 +10,7 @@ plank:
   default_decoration_configs:
     '*':
       timeout: 7200000000000 # 2h
-      grace_period: 15000000000 # 15s
+      grace_period: 60000000000 # 60s = 30s for kind containers to stop + 25s for docker to stop + 5s extra
       utility_images:
         clonerefs: "gcr.io/k8s-prow/clonerefs:v20240417-db89760fe"
         initupload: "gcr.io/k8s-prow/initupload:v20240417-db89760fe"

--- a/images/make-dind/Dockerfile
+++ b/images/make-dind/Dockerfile
@@ -21,8 +21,6 @@ LABEL maintainer="cert-manager-maintainers@googlegroups.com"
 
 # Some of these deps might already be installed in the base image but we
 # ensure they're installed here to ensure consistency
-# TODO(SgtCoDFish): The python dependency can be removed once we remove the use of Python
-# for scanning boilerplate. That saves about 50MB from the final image size.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -34,10 +32,6 @@ RUN apt-get update \
         g++ \
         zip \
         unzip \
-        python3 \
-        python3-pip \
-        python3-setuptools \
-        python3-wheel \
         wget \
         git \
         make \
@@ -75,9 +69,9 @@ RUN apt-get update \
     && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 
 # Move Docker's storage location & add Container Registry cache (see: https://cloud.google.com/container-registry/docs/pulling-cached-images)
-# @inteon: added --mtu 1460 to fix network issues due to parent mtu < child mtu (see https://blog.zespre.com/dind-mtu-size-matters.html)
-#          at the time of writing, the parent mtu is 1460 (see https://cloud.google.com/kubernetes-engine/docs/concepts/network-overview)
-RUN echo 'DOCKER_OPTS="${DOCKER_OPTS} --mtu=1460 --data-root=/docker-graph --registry-mirror=https://mirror.gcr.io"' | \
+# @inteon: added --mtu 1500 to fix network issues due to parent mtu < child mtu (see https://blog.zespre.com/dind-mtu-size-matters.html)
+#          at the time of writing, the parent mtu is 1500 (see "GKE Dataplane V2" on https://cloud.google.com/kubernetes-engine/docs/concepts/network-overview)
+RUN echo 'DOCKER_OPTS="${DOCKER_OPTS} --mtu=1500 --data-root=/docker-graph --registry-mirror=https://mirror.gcr.io"' | \
     tee --append /etc/default/docker
 
 # NOTE this should be mounted and persisted as a volume ideally (!)

--- a/images/make-dind/build.yaml
+++ b/images/make-dind/build.yaml
@@ -6,7 +6,7 @@ variants:
   bookworm:
     arguments:
       DEBIAN_VERSION: bookworm-slim
-      DOCKER_VERSION: 5:24.0.7-1~debian.12~bookworm
+      DOCKER_VERSION: 5:26.0.1-1~debian.12~bookworm
 
 # Image names to be tagged and pushed
 images:

--- a/images/make-dind/runner
+++ b/images/make-dind/runner
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TIP: use https://github.com/kubernetes/test-infra/blob/29db47ec636660a9d547e29e55d16efb27ce57b4/images/bootstrap/runner.sh#L28 as
+# inspiration for some of the hacks and tricks that we use in this file.
+
 # generic runner script, handles DIND, etc.
 
 
@@ -81,6 +84,7 @@ fi
 if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
     echo >&2 "Initializing Docker in Docker."
 
+    printf '=%.0s' {1..80}; echo >&2
     service docker start
     # The service may be marked as ready but the Docker socket may not be
     # ready yet.
@@ -98,6 +102,9 @@ if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
             break
         fi
     done
+    printf '=%.0s' {1..80}; echo >&2
+
+    echo >&2 "Done setting up docker in docker."
 fi
 
 # Disable error exit so we can run post-command cleanup.
@@ -105,6 +112,7 @@ set +o errexit
 
 # Run the actual job.
 "$@" &
+WRAPPED_COMMAND_PID=$!
 
 # Bash does not "trikle down" UNIX signals. If the Bash script receives SIGINT
 # coming from Prow due to the 2 hours timeout being hit, and that the above
@@ -122,18 +130,23 @@ set +o errexit
 #  [1]: https://github.com/kubernetes/test-infra/blob/ee1e7c8/prow/entrypoint/run.go#L242
 #  [2]: https://unix.stackexchange.com/questions/499761/what-signal-is-sent-to-running-programs-scripts-on-shutdown
 #
-# shellcheck disable=SC2064
-trap "kill -s INT $!" INT
-# shellcheck disable=SC2064
-trap "kill -s TERM $!" TERM
-wait $!
+trap 'kill -s INT "$WRAPPED_COMMAND_PID" || true' INT
+trap 'kill -s TERM "$WRAPPED_COMMAND_PID" || true' TERM
 
+wait $WRAPPED_COMMAND_PID
 EXIT_VALUE=$?
 
 # cleanup after job
 if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
-    echo "Stopping docker ..."
-    service docker stop || true
+    echo "Waiting 30 seconds for pods stopped with terminationGracePeriod:30"
+    sleep 30
+    echo "Cleaning up after docker"
+    docker ps -aq | xargs -r docker rm -f || true
+    echo "Waiting for docker to stop for 25 seconds"
+    timeout 25 service docker stop || true
+
+    # In total, we wait for 55s, add 5s for safety and we get to 60s. This
+    # 60s value is what we set as the grace period on our prowjobs (see config.yaml).
 fi
 
 if [[ "${LOCAL_CACHE_ENABLED}" == "true" ]]; then


### PR DESCRIPTION
- remove python from make-dind
- upgrade docker
- update mtu to match the new prow infrastructure
- correctly setup graceful prowjob termination based on the upstream script
