### PR TITLE
Fix runtime calculation

### DIFF
--- a/images/make-dind/runner
+++ b/images/make-dind/runner
@@ -127,7 +127,7 @@ echo "### DOCKER_IN_DOCKER_ENABLED: ${DOCKER_IN_DOCKER_ENABLED}"
 echo "###########################################"
 echo ""
 
-start=$(date +%s.%N)
+start=$(date +%s)
 
 # Run the actual job.
 "$@" &
@@ -155,7 +155,7 @@ trap 'kill -s TERM "$WRAPPED_COMMAND_PID" || true' TERM
 wait $WRAPPED_COMMAND_PID
 EXIT_VALUE=$?
 
-end=$(date +%s.%N)
+end=$(date +%s)
 
 echo ""
 echo "###########################################"

--- a/images/make-dind/runner
+++ b/images/make-dind/runner
@@ -111,7 +111,7 @@ fi
 # Disable error exit so we can run post-command cleanup.
 set +o errexit
 
-printf '\n%.0s' {1..3}; echo
+echo ""
 echo "###########################################"
 echo "############### Start test ################"
 echo "###########################################"
@@ -121,6 +121,7 @@ echo "### PROW_JOB_ID: ${PROW_JOB_ID}"
 echo "### REPO_OWNER: ${REPO_OWNER}"
 echo "### REPO_NAME: ${REPO_NAME}"
 echo "### PULL_REFS: ${PULL_REFS}"
+echo "### Command: $@"
 echo "###########################################"
 echo "### LOCAL_CACHE_ENABLED: ${LOCAL_CACHE_ENABLED}"
 echo "### DOCKER_IN_DOCKER_ENABLED: ${DOCKER_IN_DOCKER_ENABLED}"
@@ -164,7 +165,7 @@ echo "###########################################"
 echo "## EXIT_VALUE: ${EXIT_VALUE}"
 echo "## Elapsed Time: $((end-start)) seconds"
 echo "###########################################"
-printf '\n%.0s' {1..3}; echo
+echo ""
 
 # cleanup after job
 if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then


### PR DESCRIPTION
Fixes the following errors:
```
/usr/local/bin/runner: line 165: 1713439108.967950904: syntax error: invalid arithmetic operator (error token is ".967950904")
```