### PR TITLE
Add go globals to autobumper

### DIFF
--- a/config/autobump-config/testing-autobump-config.yaml
+++ b/config/autobump-config/testing-autobump-config.yaml
@@ -15,6 +15,7 @@ includedConfigPaths:
   - "prow/cluster"
 extraFiles:
   - "config/config.yaml"
+  - "config/prowgen/pkg/globals.go"
 targetVersion: "latest"
 prefixes:
   - name: "k8s-prow images"


### PR DESCRIPTION
Update the autobump config so it also tries to update the `config/prowgen/pkg/globals.go` file, which will make the verify CI tests pass on autobump PRs.