### PR TITLE
Change periodic cert-manager jobs to use cron

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -726,7 +726,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 00 01-23/02 * * *
+  cron: 00 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-23
   max_concurrency: 4
   decorate: true
@@ -777,7 +777,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 03 00-23/02 * * *
+  cron: 03 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-24
   max_concurrency: 4
   decorate: true
@@ -828,7 +828,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 06 01-23/02 * * *
+  cron: 06 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-25
   max_concurrency: 4
   decorate: true
@@ -879,7 +879,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 09 00-23/02 * * *
+  cron: 09 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-26
   max_concurrency: 4
   decorate: true
@@ -930,7 +930,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 12 01-23/02 * * *
+  cron: 12 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-27
   max_concurrency: 4
   decorate: true
@@ -981,7 +981,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 15 00-23/02 * * *
+  cron: 15 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-29
   max_concurrency: 4
   decorate: true
@@ -1032,7 +1032,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 18 01-23/02 * * *
+  cron: 18 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-28
   max_concurrency: 4
   decorate: true
@@ -1083,7 +1083,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 21 00-23/02 * * *
+  cron: 21 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-28-issuers-venafi
   max_concurrency: 4
   decorate: true
@@ -1134,7 +1134,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 24 03-23/12 * * *
+  cron: 24 00-23/12 * * *
 - name: ci-cert-manager-master-e2e-v1-28-upgrade
   max_concurrency: 4
   decorate: true
@@ -1173,7 +1173,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 27 03-23/08 * * *
+  cron: 27 00-23/08 * * *
 - name: ci-cert-manager-master-e2e-v1-28-bestpractice-install
   max_concurrency: 4
   decorate: true
@@ -1226,7 +1226,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 30 03-23/24 * * *
+  cron: 30 00-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-23-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1277,7 +1277,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 33 10-23/24 * * *
+  cron: 33 07-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-24-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1328,7 +1328,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 36 17-23/24 * * *
+  cron: 36 14-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-25-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1379,7 +1379,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 39 00-23/24 * * *
+  cron: 39 21-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-26-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1430,7 +1430,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 42 07-23/24 * * *
+  cron: 42 04-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-27-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1481,7 +1481,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 45 14-23/24 * * *
+  cron: 45 11-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-29-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1532,7 +1532,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 48 21-23/24 * * *
+  cron: 48 18-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-28-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1583,7 +1583,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 51 04-23/24 * * *
+  cron: 51 01-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-controller
   max_concurrency: 2
   decorate: true
@@ -1621,7 +1621,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 54 11-23/24 * * *
+  cron: 54 08-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-acmesolver
   max_concurrency: 2
   decorate: true
@@ -1659,7 +1659,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 57 18-23/24 * * *
+  cron: 57 15-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-startupapicheck
   max_concurrency: 2
   decorate: true
@@ -1697,7 +1697,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 00 01-23/24 * * *
+  cron: 00 22-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-cainjector
   max_concurrency: 2
   decorate: true
@@ -1735,7 +1735,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 03 08-23/24 * * *
+  cron: 03 05-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-webhook
   max_concurrency: 2
   decorate: true
@@ -1773,4 +1773,4 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 06 15-23/24 * * *
+  cron: 06 12-23/24 * * *

--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -726,7 +726,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 2h
+  cron: 00 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-23
   max_concurrency: 4
   decorate: true
@@ -777,7 +777,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 2h
+  cron: 03 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-24
   max_concurrency: 4
   decorate: true
@@ -828,7 +828,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 2h
+  cron: 06 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-25
   max_concurrency: 4
   decorate: true
@@ -879,7 +879,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 2h
+  cron: 09 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-26
   max_concurrency: 4
   decorate: true
@@ -930,7 +930,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 2h
+  cron: 12 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-27
   max_concurrency: 4
   decorate: true
@@ -981,7 +981,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 2h
+  cron: 15 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-29
   max_concurrency: 4
   decorate: true
@@ -1032,7 +1032,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 2h
+  cron: 18 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-28
   max_concurrency: 4
   decorate: true
@@ -1083,7 +1083,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 2h
+  cron: 21 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-28-issuers-venafi
   max_concurrency: 4
   decorate: true
@@ -1134,7 +1134,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 12h
+  cron: 24 00-23/12 * * *
 - name: ci-cert-manager-master-e2e-v1-28-upgrade
   max_concurrency: 4
   decorate: true
@@ -1173,7 +1173,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 8h
+  cron: 27 00-23/08 * * *
 - name: ci-cert-manager-master-e2e-v1-28-bestpractice-install
   max_concurrency: 4
   decorate: true
@@ -1226,7 +1226,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 24h
+  cron: 30 00-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-23-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1277,7 +1277,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 24h
+  cron: 33 07-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-24-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1328,7 +1328,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 24h
+  cron: 36 14-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-25-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1379,7 +1379,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 24h
+  cron: 39 21-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-26-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1430,7 +1430,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 24h
+  cron: 42 04-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-27-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1481,7 +1481,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 24h
+  cron: 45 11-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-29-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1532,7 +1532,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 24h
+  cron: 48 18-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-28-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1583,7 +1583,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 24h
+  cron: 51 01-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-controller
   max_concurrency: 2
   decorate: true
@@ -1621,7 +1621,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 24h
+  cron: 54 08-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-acmesolver
   max_concurrency: 2
   decorate: true
@@ -1659,7 +1659,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 24h
+  cron: 57 15-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-startupapicheck
   max_concurrency: 2
   decorate: true
@@ -1697,7 +1697,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 24h
+  cron: 00 22-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-cainjector
   max_concurrency: 2
   decorate: true
@@ -1735,7 +1735,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 24h
+  cron: 03 05-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-webhook
   max_concurrency: 2
   decorate: true
@@ -1773,4 +1773,4 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  interval: 24h
+  cron: 06 12-23/24 * * *

--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -726,7 +726,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 00 00-23/02 * * *
+  cron: 00 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-23
   max_concurrency: 4
   decorate: true
@@ -777,7 +777,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 03 01-23/02 * * *
+  cron: 03 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-24
   max_concurrency: 4
   decorate: true
@@ -828,7 +828,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 06 00-23/02 * * *
+  cron: 06 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-25
   max_concurrency: 4
   decorate: true
@@ -879,7 +879,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 09 01-23/02 * * *
+  cron: 09 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-26
   max_concurrency: 4
   decorate: true
@@ -930,7 +930,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 12 00-23/02 * * *
+  cron: 12 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-27
   max_concurrency: 4
   decorate: true
@@ -981,7 +981,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 15 01-23/02 * * *
+  cron: 15 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-29
   max_concurrency: 4
   decorate: true
@@ -1032,7 +1032,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 18 00-23/02 * * *
+  cron: 18 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-28
   max_concurrency: 4
   decorate: true
@@ -1083,7 +1083,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 21 01-23/02 * * *
+  cron: 21 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-28-issuers-venafi
   max_concurrency: 4
   decorate: true
@@ -1134,7 +1134,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 24 00-23/12 * * *
+  cron: 24 03-23/12 * * *
 - name: ci-cert-manager-master-e2e-v1-28-upgrade
   max_concurrency: 4
   decorate: true
@@ -1173,7 +1173,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 27 00-23/08 * * *
+  cron: 27 03-23/08 * * *
 - name: ci-cert-manager-master-e2e-v1-28-bestpractice-install
   max_concurrency: 4
   decorate: true
@@ -1226,7 +1226,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 30 00-23/24 * * *
+  cron: 30 03-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-23-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1277,7 +1277,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 33 07-23/24 * * *
+  cron: 33 10-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-24-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1328,7 +1328,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 36 14-23/24 * * *
+  cron: 36 17-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-25-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1379,7 +1379,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 39 21-23/24 * * *
+  cron: 39 00-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-26-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1430,7 +1430,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 42 04-23/24 * * *
+  cron: 42 07-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-27-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1481,7 +1481,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 45 11-23/24 * * *
+  cron: 45 14-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-29-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1532,7 +1532,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 48 18-23/24 * * *
+  cron: 48 21-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-28-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1583,7 +1583,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 51 01-23/24 * * *
+  cron: 51 04-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-controller
   max_concurrency: 2
   decorate: true
@@ -1621,7 +1621,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 54 08-23/24 * * *
+  cron: 54 11-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-acmesolver
   max_concurrency: 2
   decorate: true
@@ -1659,7 +1659,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 57 15-23/24 * * *
+  cron: 57 18-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-startupapicheck
   max_concurrency: 2
   decorate: true
@@ -1697,7 +1697,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 00 22-23/24 * * *
+  cron: 00 01-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-cainjector
   max_concurrency: 2
   decorate: true
@@ -1735,7 +1735,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 03 05-23/24 * * *
+  cron: 03 08-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-webhook
   max_concurrency: 2
   decorate: true
@@ -1773,4 +1773,4 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 06 12-23/24 * * *
+  cron: 06 15-23/24 * * *

--- a/config/jobs/cert-manager/cert-manager/release-1.12/cert-manager-release-1.12.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.12/cert-manager-release-1.12.yaml
@@ -634,7 +634,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 00 00-23/02 * * *
+  cron: 01 01-23/02 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-22
   max_concurrency: 4
   decorate: true
@@ -685,7 +685,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 03 01-23/02 * * *
+  cron: 04 00-23/02 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-23
   max_concurrency: 4
   decorate: true
@@ -736,7 +736,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 06 00-23/02 * * *
+  cron: 07 01-23/02 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-24
   max_concurrency: 4
   decorate: true
@@ -787,7 +787,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 09 01-23/02 * * *
+  cron: 10 00-23/02 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-25
   max_concurrency: 4
   decorate: true
@@ -838,7 +838,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 12 00-23/02 * * *
+  cron: 13 01-23/02 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-26
   max_concurrency: 4
   decorate: true
@@ -889,7 +889,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 15 01-23/02 * * *
+  cron: 16 00-23/02 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-27
   max_concurrency: 4
   decorate: true
@@ -940,7 +940,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 18 00-23/02 * * *
+  cron: 19 01-23/02 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-27-issuers-venafi
   max_concurrency: 4
   decorate: true
@@ -991,7 +991,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 21 00-23/12 * * *
+  cron: 22 01-23/12 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-27-upgrade
   max_concurrency: 4
   decorate: true
@@ -1030,7 +1030,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 24 00-23/08 * * *
+  cron: 25 01-23/08 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-27-bestpractice-install
   max_concurrency: 4
   decorate: true
@@ -1083,7 +1083,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 27 00-23/24 * * *
+  cron: 28 01-23/24 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-22-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1134,7 +1134,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 30 07-23/24 * * *
+  cron: 31 08-23/24 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-23-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1185,7 +1185,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 33 14-23/24 * * *
+  cron: 34 15-23/24 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-24-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1236,7 +1236,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 36 21-23/24 * * *
+  cron: 37 22-23/24 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-25-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1287,7 +1287,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 39 04-23/24 * * *
+  cron: 40 05-23/24 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-26-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1338,7 +1338,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 42 11-23/24 * * *
+  cron: 43 12-23/24 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-27-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1389,7 +1389,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 45 18-23/24 * * *
+  cron: 46 19-23/24 * * *
 - name: ci-cert-manager-release-1.12-trivy-test-controller
   max_concurrency: 2
   decorate: true
@@ -1427,7 +1427,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 48 01-23/24 * * *
+  cron: 49 02-23/24 * * *
 - name: ci-cert-manager-release-1.12-trivy-test-acmesolver
   max_concurrency: 2
   decorate: true
@@ -1465,7 +1465,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 51 08-23/24 * * *
+  cron: 52 09-23/24 * * *
 - name: ci-cert-manager-release-1.12-trivy-test-ctl
   max_concurrency: 2
   decorate: true
@@ -1503,7 +1503,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 54 15-23/24 * * *
+  cron: 55 16-23/24 * * *
 - name: ci-cert-manager-release-1.12-trivy-test-cainjector
   max_concurrency: 2
   decorate: true
@@ -1541,7 +1541,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 57 22-23/24 * * *
+  cron: 58 23-23/24 * * *
 - name: ci-cert-manager-release-1.12-trivy-test-webhook
   max_concurrency: 2
   decorate: true
@@ -1579,4 +1579,4 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 00 05-23/24 * * *
+  cron: 01 06-23/24 * * *

--- a/config/jobs/cert-manager/cert-manager/release-1.12/cert-manager-release-1.12.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.12/cert-manager-release-1.12.yaml
@@ -634,7 +634,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 2h
+  cron: 00 00-23/02 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-22
   max_concurrency: 4
   decorate: true
@@ -685,7 +685,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 2h
+  cron: 03 01-23/02 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-23
   max_concurrency: 4
   decorate: true
@@ -736,7 +736,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 2h
+  cron: 06 00-23/02 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-24
   max_concurrency: 4
   decorate: true
@@ -787,7 +787,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 2h
+  cron: 09 01-23/02 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-25
   max_concurrency: 4
   decorate: true
@@ -838,7 +838,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 2h
+  cron: 12 00-23/02 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-26
   max_concurrency: 4
   decorate: true
@@ -889,7 +889,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 2h
+  cron: 15 01-23/02 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-27
   max_concurrency: 4
   decorate: true
@@ -940,7 +940,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 2h
+  cron: 18 00-23/02 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-27-issuers-venafi
   max_concurrency: 4
   decorate: true
@@ -991,7 +991,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 12h
+  cron: 21 00-23/12 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-27-upgrade
   max_concurrency: 4
   decorate: true
@@ -1030,7 +1030,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 8h
+  cron: 24 00-23/08 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-27-bestpractice-install
   max_concurrency: 4
   decorate: true
@@ -1083,7 +1083,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 24h
+  cron: 27 00-23/24 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-22-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1134,7 +1134,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 24h
+  cron: 30 07-23/24 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-23-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1185,7 +1185,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 24h
+  cron: 33 14-23/24 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-24-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1236,7 +1236,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 24h
+  cron: 36 21-23/24 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-25-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1287,7 +1287,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 24h
+  cron: 39 04-23/24 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-26-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1338,7 +1338,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 24h
+  cron: 42 11-23/24 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-27-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1389,7 +1389,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 24h
+  cron: 45 18-23/24 * * *
 - name: ci-cert-manager-release-1.12-trivy-test-controller
   max_concurrency: 2
   decorate: true
@@ -1427,7 +1427,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 24h
+  cron: 48 01-23/24 * * *
 - name: ci-cert-manager-release-1.12-trivy-test-acmesolver
   max_concurrency: 2
   decorate: true
@@ -1465,7 +1465,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 24h
+  cron: 51 08-23/24 * * *
 - name: ci-cert-manager-release-1.12-trivy-test-ctl
   max_concurrency: 2
   decorate: true
@@ -1503,7 +1503,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 24h
+  cron: 54 15-23/24 * * *
 - name: ci-cert-manager-release-1.12-trivy-test-cainjector
   max_concurrency: 2
   decorate: true
@@ -1541,7 +1541,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 24h
+  cron: 57 22-23/24 * * *
 - name: ci-cert-manager-release-1.12-trivy-test-webhook
   max_concurrency: 2
   decorate: true
@@ -1579,4 +1579,4 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  interval: 24h
+  cron: 00 05-23/24 * * *

--- a/config/jobs/cert-manager/cert-manager/release-1.13/cert-manager-release-1.13.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.13/cert-manager-release-1.13.yaml
@@ -634,7 +634,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 00 00-23/02 * * *
+  cron: 01 01-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-23
   max_concurrency: 4
   decorate: true
@@ -685,7 +685,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 03 01-23/02 * * *
+  cron: 04 00-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-24
   max_concurrency: 4
   decorate: true
@@ -736,7 +736,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 06 00-23/02 * * *
+  cron: 07 01-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-25
   max_concurrency: 4
   decorate: true
@@ -787,7 +787,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 09 01-23/02 * * *
+  cron: 10 00-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-26
   max_concurrency: 4
   decorate: true
@@ -838,7 +838,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 12 00-23/02 * * *
+  cron: 13 01-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-27
   max_concurrency: 4
   decorate: true
@@ -889,7 +889,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 15 01-23/02 * * *
+  cron: 16 00-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-28
   max_concurrency: 4
   decorate: true
@@ -940,7 +940,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 18 00-23/02 * * *
+  cron: 19 01-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-28-issuers-venafi
   max_concurrency: 4
   decorate: true
@@ -991,7 +991,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 21 00-23/12 * * *
+  cron: 22 01-23/12 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-28-upgrade
   max_concurrency: 4
   decorate: true
@@ -1030,7 +1030,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 24 00-23/08 * * *
+  cron: 25 01-23/08 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-28-bestpractice-install
   max_concurrency: 4
   decorate: true
@@ -1083,7 +1083,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 27 00-23/24 * * *
+  cron: 28 01-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-23-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1134,7 +1134,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 30 07-23/24 * * *
+  cron: 31 08-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-24-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1185,7 +1185,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 33 14-23/24 * * *
+  cron: 34 15-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-25-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1236,7 +1236,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 36 21-23/24 * * *
+  cron: 37 22-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-26-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1287,7 +1287,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 39 04-23/24 * * *
+  cron: 40 05-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-27-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1338,7 +1338,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 42 11-23/24 * * *
+  cron: 43 12-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-28-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1389,7 +1389,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 45 18-23/24 * * *
+  cron: 46 19-23/24 * * *
 - name: ci-cert-manager-release-1.13-trivy-test-controller
   max_concurrency: 2
   decorate: true
@@ -1427,7 +1427,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 48 01-23/24 * * *
+  cron: 49 02-23/24 * * *
 - name: ci-cert-manager-release-1.13-trivy-test-acmesolver
   max_concurrency: 2
   decorate: true
@@ -1465,7 +1465,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 51 08-23/24 * * *
+  cron: 52 09-23/24 * * *
 - name: ci-cert-manager-release-1.13-trivy-test-ctl
   max_concurrency: 2
   decorate: true
@@ -1503,7 +1503,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 54 15-23/24 * * *
+  cron: 55 16-23/24 * * *
 - name: ci-cert-manager-release-1.13-trivy-test-cainjector
   max_concurrency: 2
   decorate: true
@@ -1541,7 +1541,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 57 22-23/24 * * *
+  cron: 58 23-23/24 * * *
 - name: ci-cert-manager-release-1.13-trivy-test-webhook
   max_concurrency: 2
   decorate: true
@@ -1579,4 +1579,4 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 00 05-23/24 * * *
+  cron: 01 06-23/24 * * *

--- a/config/jobs/cert-manager/cert-manager/release-1.13/cert-manager-release-1.13.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.13/cert-manager-release-1.13.yaml
@@ -634,7 +634,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 2h
+  cron: 00 00-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-23
   max_concurrency: 4
   decorate: true
@@ -685,7 +685,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 2h
+  cron: 03 01-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-24
   max_concurrency: 4
   decorate: true
@@ -736,7 +736,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 2h
+  cron: 06 00-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-25
   max_concurrency: 4
   decorate: true
@@ -787,7 +787,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 2h
+  cron: 09 01-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-26
   max_concurrency: 4
   decorate: true
@@ -838,7 +838,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 2h
+  cron: 12 00-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-27
   max_concurrency: 4
   decorate: true
@@ -889,7 +889,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 2h
+  cron: 15 01-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-28
   max_concurrency: 4
   decorate: true
@@ -940,7 +940,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 2h
+  cron: 18 00-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-28-issuers-venafi
   max_concurrency: 4
   decorate: true
@@ -991,7 +991,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 12h
+  cron: 21 00-23/12 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-28-upgrade
   max_concurrency: 4
   decorate: true
@@ -1030,7 +1030,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 8h
+  cron: 24 00-23/08 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-28-bestpractice-install
   max_concurrency: 4
   decorate: true
@@ -1083,7 +1083,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 24h
+  cron: 27 00-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-23-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1134,7 +1134,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 24h
+  cron: 30 07-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-24-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1185,7 +1185,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 24h
+  cron: 33 14-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-25-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1236,7 +1236,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 24h
+  cron: 36 21-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-26-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1287,7 +1287,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 24h
+  cron: 39 04-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-27-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1338,7 +1338,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 24h
+  cron: 42 11-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-28-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1389,7 +1389,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 24h
+  cron: 45 18-23/24 * * *
 - name: ci-cert-manager-release-1.13-trivy-test-controller
   max_concurrency: 2
   decorate: true
@@ -1427,7 +1427,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 24h
+  cron: 48 01-23/24 * * *
 - name: ci-cert-manager-release-1.13-trivy-test-acmesolver
   max_concurrency: 2
   decorate: true
@@ -1465,7 +1465,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 24h
+  cron: 51 08-23/24 * * *
 - name: ci-cert-manager-release-1.13-trivy-test-ctl
   max_concurrency: 2
   decorate: true
@@ -1503,7 +1503,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 24h
+  cron: 54 15-23/24 * * *
 - name: ci-cert-manager-release-1.13-trivy-test-cainjector
   max_concurrency: 2
   decorate: true
@@ -1541,7 +1541,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 24h
+  cron: 57 22-23/24 * * *
 - name: ci-cert-manager-release-1.13-trivy-test-webhook
   max_concurrency: 2
   decorate: true
@@ -1579,4 +1579,4 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  interval: 24h
+  cron: 00 05-23/24 * * *

--- a/config/jobs/cert-manager/cert-manager/release-1.13/cert-manager-release-1.13.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.13/cert-manager-release-1.13.yaml
@@ -634,7 +634,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 01 01-23/02 * * *
+  cron: 02 00-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-23
   max_concurrency: 4
   decorate: true
@@ -685,7 +685,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 04 00-23/02 * * *
+  cron: 05 01-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-24
   max_concurrency: 4
   decorate: true
@@ -736,7 +736,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 07 01-23/02 * * *
+  cron: 08 00-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-25
   max_concurrency: 4
   decorate: true
@@ -787,7 +787,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 10 00-23/02 * * *
+  cron: 11 01-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-26
   max_concurrency: 4
   decorate: true
@@ -838,7 +838,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 13 01-23/02 * * *
+  cron: 14 00-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-27
   max_concurrency: 4
   decorate: true
@@ -889,7 +889,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 16 00-23/02 * * *
+  cron: 17 01-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-28
   max_concurrency: 4
   decorate: true
@@ -940,7 +940,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 19 01-23/02 * * *
+  cron: 20 00-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-28-issuers-venafi
   max_concurrency: 4
   decorate: true
@@ -991,7 +991,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 22 01-23/12 * * *
+  cron: 23 02-23/12 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-28-upgrade
   max_concurrency: 4
   decorate: true
@@ -1030,7 +1030,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 25 01-23/08 * * *
+  cron: 26 02-23/08 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-28-bestpractice-install
   max_concurrency: 4
   decorate: true
@@ -1083,7 +1083,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 28 01-23/24 * * *
+  cron: 29 02-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-23-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1134,7 +1134,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 31 08-23/24 * * *
+  cron: 32 09-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-24-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1185,7 +1185,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 34 15-23/24 * * *
+  cron: 35 16-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-25-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1236,7 +1236,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 37 22-23/24 * * *
+  cron: 38 23-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-26-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1287,7 +1287,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 40 05-23/24 * * *
+  cron: 41 06-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-27-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1338,7 +1338,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 43 12-23/24 * * *
+  cron: 44 13-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-28-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1389,7 +1389,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 46 19-23/24 * * *
+  cron: 47 20-23/24 * * *
 - name: ci-cert-manager-release-1.13-trivy-test-controller
   max_concurrency: 2
   decorate: true
@@ -1427,7 +1427,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 49 02-23/24 * * *
+  cron: 50 03-23/24 * * *
 - name: ci-cert-manager-release-1.13-trivy-test-acmesolver
   max_concurrency: 2
   decorate: true
@@ -1465,7 +1465,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 52 09-23/24 * * *
+  cron: 53 10-23/24 * * *
 - name: ci-cert-manager-release-1.13-trivy-test-ctl
   max_concurrency: 2
   decorate: true
@@ -1503,7 +1503,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 55 16-23/24 * * *
+  cron: 56 17-23/24 * * *
 - name: ci-cert-manager-release-1.13-trivy-test-cainjector
   max_concurrency: 2
   decorate: true
@@ -1541,7 +1541,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 58 23-23/24 * * *
+  cron: 59 00-23/24 * * *
 - name: ci-cert-manager-release-1.13-trivy-test-webhook
   max_concurrency: 2
   decorate: true
@@ -1579,4 +1579,4 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 01 06-23/24 * * *
+  cron: 02 07-23/24 * * *

--- a/config/jobs/cert-manager/cert-manager/release-1.14/cert-manager-release-1.14.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.14/cert-manager-release-1.14.yaml
@@ -634,7 +634,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 02 00-23/02 * * *
+  cron: 00 01-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-24
   max_concurrency: 4
   decorate: true
@@ -685,7 +685,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 05 01-23/02 * * *
+  cron: 03 00-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-25
   max_concurrency: 4
   decorate: true
@@ -736,7 +736,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 08 00-23/02 * * *
+  cron: 06 01-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-26
   max_concurrency: 4
   decorate: true
@@ -787,7 +787,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 11 01-23/02 * * *
+  cron: 09 00-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-27
   max_concurrency: 4
   decorate: true
@@ -838,7 +838,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 14 00-23/02 * * *
+  cron: 12 01-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-28
   max_concurrency: 4
   decorate: true
@@ -889,7 +889,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 17 01-23/02 * * *
+  cron: 15 00-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-29
   max_concurrency: 4
   decorate: true
@@ -940,7 +940,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 20 00-23/02 * * *
+  cron: 18 01-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-29-issuers-venafi
   max_concurrency: 4
   decorate: true
@@ -991,7 +991,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 23 02-23/12 * * *
+  cron: 21 03-23/12 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-29-upgrade
   max_concurrency: 4
   decorate: true
@@ -1030,7 +1030,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 26 02-23/08 * * *
+  cron: 24 03-23/08 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-29-bestpractice-install
   max_concurrency: 4
   decorate: true
@@ -1083,7 +1083,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 29 02-23/24 * * *
+  cron: 27 03-23/24 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-24-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1134,7 +1134,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 32 09-23/24 * * *
+  cron: 30 10-23/24 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-25-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1185,7 +1185,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 35 16-23/24 * * *
+  cron: 33 17-23/24 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-26-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1236,7 +1236,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 38 23-23/24 * * *
+  cron: 36 00-23/24 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-27-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1287,7 +1287,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 41 06-23/24 * * *
+  cron: 39 07-23/24 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-28-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1338,7 +1338,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 44 13-23/24 * * *
+  cron: 42 14-23/24 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-29-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1389,7 +1389,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 47 20-23/24 * * *
+  cron: 45 21-23/24 * * *
 - name: ci-cert-manager-release-1.14-trivy-test-controller
   max_concurrency: 2
   decorate: true
@@ -1427,7 +1427,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 50 03-23/24 * * *
+  cron: 48 04-23/24 * * *
 - name: ci-cert-manager-release-1.14-trivy-test-acmesolver
   max_concurrency: 2
   decorate: true
@@ -1465,7 +1465,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 53 10-23/24 * * *
+  cron: 51 11-23/24 * * *
 - name: ci-cert-manager-release-1.14-trivy-test-ctl
   max_concurrency: 2
   decorate: true
@@ -1503,7 +1503,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 56 17-23/24 * * *
+  cron: 54 18-23/24 * * *
 - name: ci-cert-manager-release-1.14-trivy-test-startupapicheck
   max_concurrency: 2
   decorate: true
@@ -1541,7 +1541,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 59 00-23/24 * * *
+  cron: 57 01-23/24 * * *
 - name: ci-cert-manager-release-1.14-trivy-test-cainjector
   max_concurrency: 2
   decorate: true
@@ -1579,7 +1579,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 02 07-23/24 * * *
+  cron: 00 08-23/24 * * *
 - name: ci-cert-manager-release-1.14-trivy-test-webhook
   max_concurrency: 2
   decorate: true
@@ -1617,4 +1617,4 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 05 14-23/24 * * *
+  cron: 03 15-23/24 * * *

--- a/config/jobs/cert-manager/cert-manager/release-1.14/cert-manager-release-1.14.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.14/cert-manager-release-1.14.yaml
@@ -634,7 +634,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 2h
+  cron: 00 00-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-24
   max_concurrency: 4
   decorate: true
@@ -685,7 +685,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 2h
+  cron: 03 01-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-25
   max_concurrency: 4
   decorate: true
@@ -736,7 +736,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 2h
+  cron: 06 00-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-26
   max_concurrency: 4
   decorate: true
@@ -787,7 +787,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 2h
+  cron: 09 01-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-27
   max_concurrency: 4
   decorate: true
@@ -838,7 +838,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 2h
+  cron: 12 00-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-28
   max_concurrency: 4
   decorate: true
@@ -889,7 +889,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 2h
+  cron: 15 01-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-29
   max_concurrency: 4
   decorate: true
@@ -940,7 +940,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 2h
+  cron: 18 00-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-29-issuers-venafi
   max_concurrency: 4
   decorate: true
@@ -991,7 +991,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 12h
+  cron: 21 00-23/12 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-29-upgrade
   max_concurrency: 4
   decorate: true
@@ -1030,7 +1030,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 8h
+  cron: 24 00-23/08 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-29-bestpractice-install
   max_concurrency: 4
   decorate: true
@@ -1083,7 +1083,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 24h
+  cron: 27 00-23/24 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-24-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1134,7 +1134,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 24h
+  cron: 30 07-23/24 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-25-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1185,7 +1185,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 24h
+  cron: 33 14-23/24 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-26-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1236,7 +1236,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 24h
+  cron: 36 21-23/24 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-27-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1287,7 +1287,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 24h
+  cron: 39 04-23/24 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-28-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1338,7 +1338,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 24h
+  cron: 42 11-23/24 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-29-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1389,7 +1389,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 24h
+  cron: 45 18-23/24 * * *
 - name: ci-cert-manager-release-1.14-trivy-test-controller
   max_concurrency: 2
   decorate: true
@@ -1427,7 +1427,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 24h
+  cron: 48 01-23/24 * * *
 - name: ci-cert-manager-release-1.14-trivy-test-acmesolver
   max_concurrency: 2
   decorate: true
@@ -1465,7 +1465,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 24h
+  cron: 51 08-23/24 * * *
 - name: ci-cert-manager-release-1.14-trivy-test-ctl
   max_concurrency: 2
   decorate: true
@@ -1503,7 +1503,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 24h
+  cron: 54 15-23/24 * * *
 - name: ci-cert-manager-release-1.14-trivy-test-startupapicheck
   max_concurrency: 2
   decorate: true
@@ -1541,7 +1541,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 24h
+  cron: 57 22-23/24 * * *
 - name: ci-cert-manager-release-1.14-trivy-test-cainjector
   max_concurrency: 2
   decorate: true
@@ -1579,7 +1579,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 24h
+  cron: 00 05-23/24 * * *
 - name: ci-cert-manager-release-1.14-trivy-test-webhook
   max_concurrency: 2
   decorate: true
@@ -1617,4 +1617,4 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  interval: 24h
+  cron: 03 12-23/24 * * *

--- a/config/jobs/cert-manager/cert-manager/release-1.14/cert-manager-release-1.14.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.14/cert-manager-release-1.14.yaml
@@ -634,7 +634,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 00 00-23/02 * * *
+  cron: 02 00-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-24
   max_concurrency: 4
   decorate: true
@@ -685,7 +685,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 03 01-23/02 * * *
+  cron: 05 01-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-25
   max_concurrency: 4
   decorate: true
@@ -736,7 +736,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 06 00-23/02 * * *
+  cron: 08 00-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-26
   max_concurrency: 4
   decorate: true
@@ -787,7 +787,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 09 01-23/02 * * *
+  cron: 11 01-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-27
   max_concurrency: 4
   decorate: true
@@ -838,7 +838,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 12 00-23/02 * * *
+  cron: 14 00-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-28
   max_concurrency: 4
   decorate: true
@@ -889,7 +889,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 15 01-23/02 * * *
+  cron: 17 01-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-29
   max_concurrency: 4
   decorate: true
@@ -940,7 +940,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 18 00-23/02 * * *
+  cron: 20 00-23/02 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-29-issuers-venafi
   max_concurrency: 4
   decorate: true
@@ -991,7 +991,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 21 00-23/12 * * *
+  cron: 23 02-23/12 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-29-upgrade
   max_concurrency: 4
   decorate: true
@@ -1030,7 +1030,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 24 00-23/08 * * *
+  cron: 26 02-23/08 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-29-bestpractice-install
   max_concurrency: 4
   decorate: true
@@ -1083,7 +1083,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 27 00-23/24 * * *
+  cron: 29 02-23/24 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-24-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1134,7 +1134,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 30 07-23/24 * * *
+  cron: 32 09-23/24 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-25-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1185,7 +1185,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 33 14-23/24 * * *
+  cron: 35 16-23/24 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-26-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1236,7 +1236,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 36 21-23/24 * * *
+  cron: 38 23-23/24 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-27-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1287,7 +1287,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 39 04-23/24 * * *
+  cron: 41 06-23/24 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-28-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1338,7 +1338,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 42 11-23/24 * * *
+  cron: 44 13-23/24 * * *
 - name: ci-cert-manager-release-1.14-e2e-v1-29-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1389,7 +1389,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 45 18-23/24 * * *
+  cron: 47 20-23/24 * * *
 - name: ci-cert-manager-release-1.14-trivy-test-controller
   max_concurrency: 2
   decorate: true
@@ -1427,7 +1427,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 48 01-23/24 * * *
+  cron: 50 03-23/24 * * *
 - name: ci-cert-manager-release-1.14-trivy-test-acmesolver
   max_concurrency: 2
   decorate: true
@@ -1465,7 +1465,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 51 08-23/24 * * *
+  cron: 53 10-23/24 * * *
 - name: ci-cert-manager-release-1.14-trivy-test-ctl
   max_concurrency: 2
   decorate: true
@@ -1503,7 +1503,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 54 15-23/24 * * *
+  cron: 56 17-23/24 * * *
 - name: ci-cert-manager-release-1.14-trivy-test-startupapicheck
   max_concurrency: 2
   decorate: true
@@ -1541,7 +1541,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 57 22-23/24 * * *
+  cron: 59 00-23/24 * * *
 - name: ci-cert-manager-release-1.14-trivy-test-cainjector
   max_concurrency: 2
   decorate: true
@@ -1579,7 +1579,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 00 05-23/24 * * *
+  cron: 02 07-23/24 * * *
 - name: ci-cert-manager-release-1.14-trivy-test-webhook
   max_concurrency: 2
   decorate: true
@@ -1617,4 +1617,4 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.14
-  cron: 03 12-23/24 * * *
+  cron: 05 14-23/24 * * *

--- a/config/prowgen/pkg/context.go
+++ b/config/prowgen/pkg/context.go
@@ -19,8 +19,7 @@ package pkg
 
 import (
 	"fmt"
-	"strconv"
-	"time"
+	"math"
 )
 
 // ProwContext holds jobs and information required to configure jobs for a given release channel.
@@ -51,8 +50,6 @@ type ProwContext struct {
 
 	presubmits []*PresubmitJob
 	periodics  []*PeriodicJob
-
-	minutesCounter time.Time
 }
 
 // RequiredPresubmit adds a presubmit which is run by default and required to pass before a PR can be merged
@@ -116,17 +113,74 @@ func (pc *ProwContext) Periodics(job *Job, periodicityHours int) {
 				BaseRef: pc.Branch,
 			},
 		},
-		Interval: strconv.Itoa(periodicityHours) + "h",
-		// TODO: use Cron instead of Interval
-		// Cron: pc.cronSchedule(periodicityHours),
+		PeriodicityHours: periodicityHours,
+		// Use a minute and startHour of 0 when adding the period here, but in JobFile
+		// when we actually generate the JobFile struct we'll recalculate values
+		// to spread the periodics evenly across every hour / day
+		Cron: cronSchedule(0, 0, periodicityHours),
 	})
 }
 
 func (pc *ProwContext) JobFile() *JobFile {
-	// TODO: when using Cron instead of Interval for periodics, adjust all periodics
-	// here to spread them evenly throughout the hour
-
 	presubmitKey := fmt.Sprintf("%s/%s", pc.Org, pc.Repo)
+
+	// By dividing 60 by the number of periodics we get the maximum number of minutes
+	// apart which we can schedule jobs, in an effort to maximise the amount of time
+	// that each job could theoretically run without anything else running in parallel.
+
+	// We aim to maximise the amount of CPU available to each job at startup, which is
+	// often when most jobs need a lot of CPU (e.g. to set up tests / clusters)
+	// We use ceil because more spreading isn't a bad thing
+	minuteSpread := int(math.Ceil(60.0 / float64(len(pc.periodics))))
+
+	// Count the number of jobs with each periodicity to make it easier to spread them later
+	periodicityCounts := map[int]int{}
+
+	for _, p := range pc.periodics {
+		periodicityCounts[p.PeriodicityHours] += 1
+	}
+
+	// periodicitySeen is used to track how many times we've seen a job with a given
+	// periodicity, which allows us to spread jobs with the same periodicity across the day
+	periodicitySeen := map[int]int{}
+
+	for i, p := range pc.periodics {
+		minute := (i * minuteSpread) % 60
+
+		// hourCounter is how many jobs with the same periodicity we've already seen
+		hourCounter := periodicitySeen[p.PeriodicityHours]
+
+		periodicitySeen[p.PeriodicityHours] = hourCounter + 1
+
+		// Hour spread is how far apart we can place jobs in starting hours
+		// E.g. Say we have 5 jobs with periodicity 4.
+		// (Bear in mind these jobs can only start in hours 0,1,2,3 [1])
+		// ceil(4/5) = 1, meaning we have to place a job every hour and can't space them out any more.
+
+		// If we instead had 3 jobs with periodicity 8, ceil(8/3) = 3 and so we can place jobs at
+		// 0,3,6 (or 1,4,7) to spread them out more.
+
+		// [1] Effectively we operate modulo the periodicity; if (start hour >= periodicity) it
+		// reduces the number of invocations possible in a calendar day, e.g.:
+		// "0 7-23/8 * * *" runs 3 times in a day (at 07:00, 15:00 and 23:00), but
+		// "0 8-23/8 * * *" only runs twice (at 08:00 and 16:00)
+		hourSpread := int(math.Floor(float64(p.PeriodicityHours) / float64(periodicityCounts[p.PeriodicityHours])))
+		if hourSpread == 0 {
+			hourSpread = 1
+		}
+
+		if p.PeriodicityHours == 24 {
+			// 24h periodicity is different because it can be started at any hour and will always be run
+			// once per day
+			// In this case, just set the spread to 7 which gives a pretty good spread modulo 24:
+			// [0, 7, 14, 21, 4, 11, 18, 1, 8, 15, 22, 5, 12, 19, 2, 9, 16, 23, 6, 13, 20, 3, 10, 17]
+			hourSpread = 7
+		}
+
+		startHour := (hourSpread * hourCounter) % p.PeriodicityHours
+
+		p.Cron = cronSchedule(minute, startHour, p.PeriodicityHours)
+	}
 
 	return &JobFile{
 		Presubmits: map[string][]*PresubmitJob{
@@ -156,19 +210,6 @@ func (pc *ProwContext) periodicDashboardName() string {
 	return fmt.Sprintf("%s-periodics-%s", pc.Repo, pc.Branch)
 }
 
-func (pc *ProwContext) cronSchedule(periodicityHours int) string {
-	minute := pc.minutesValue()
-
-	return fmt.Sprintf("*/%d %d * * *", minute, periodicityHours)
-}
-
-// minutesValue returns a minute value (0 - 59) at which a test should be run and then
-// increases the next value returned. This helps to prevent every test running at the same
-// minute within the hour causing a spiky distribution of tests.
-func (pc *ProwContext) minutesValue() int {
-	minuteVal := pc.minutesCounter.Minute()
-
-	pc.minutesCounter = pc.minutesCounter.Add(4 * time.Minute)
-
-	return minuteVal
+func cronSchedule(minute int, startHour int, periodicityHours int) string {
+	return fmt.Sprintf("%02d %02d-23/%02d * * *", minute, startHour, periodicityHours)
 }

--- a/config/prowgen/pkg/context.go
+++ b/config/prowgen/pkg/context.go
@@ -114,10 +114,9 @@ func (pc *ProwContext) Periodics(job *Job, periodicityHours int) {
 			},
 		},
 		PeriodicityHours: periodicityHours,
-		// Use a minute and startHour of 0 when adding the period here, but in JobFile
-		// when we actually generate the JobFile struct we'll recalculate values
-		// to spread the periodics evenly across every hour / day
-		Cron: cronSchedule(0, 0, periodicityHours),
+		// Cron is filled later after all periodics are known, to maximise our ability
+		// to spread jobs over the time available
+		Cron: "FILLED LATER",
 	})
 }
 

--- a/config/prowgen/pkg/types.go
+++ b/config/prowgen/pkg/types.go
@@ -126,8 +126,12 @@ type PeriodicJob struct {
 
 	ExtraRefs []ExtraRef `yaml:"extra_refs"`
 
-	Cron     string `yaml:"cron,omitempty"`
-	Interval string `yaml:"interval,omitempty"`
+	// PeriodicityHours isn't present in upstream structs; we use it to track when
+	// a job should recur. Keeping track of this allows us to spread jobs across
+	// time after we know how many jobs we have to avoid several being scheduled at once.
+	PeriodicityHours int `yaml:"-"`
+
+	Cron string `yaml:"cron,omitempty"`
 }
 
 type ExtraRef struct {

--- a/config/prowgen/prowspecs/specs.go
+++ b/config/prowgen/prowspecs/specs.go
@@ -19,6 +19,7 @@ package prowspecs
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"prowgen/pkg"
@@ -211,6 +212,7 @@ func KnownBranches() []string {
 		availableBranches = append(availableBranches, branch)
 	}
 
+	slices.Sort(availableBranches)
 	return availableBranches
 }
 


### PR DESCRIPTION
This spreads the jobs pretty well throughout the day to try and minimise the amount of compute we're using for any one instant of cert-manager tests.

This algorithm seems to give reasonable performance in spread without spending too much time digging into making it perfect.

I've attempted to comment it as much as possible because I know it's likely to be harder to read than it was to write.