### PR TITLE
Add custom version of prow-controller-manager with better support for spot instances

### DIFF
--- a/config/jobs/testing/testing-postsubmits-trusted.yaml
+++ b/config/jobs/testing/testing-postsubmits-trusted.yaml
@@ -73,6 +73,41 @@ postsubmits:
           capabilities:
             add: ["SYS_ADMIN"]
 
+  - name: post-testing-push-prow-controller-manager-spot
+    cluster: prow-trusted
+    run_if_changed: '^images/prow-controller-manager-spot/'
+    branches:
+    - master
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-deployer-service-account: "true"
+      preset-deployer-github-token: "true"
+      preset-deployer-ssh-key: "true"
+    annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: cert-manager-testing-janitors
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-disable-prowjob-analysis: "true"
+      description: Build and push the 'prow-controller-manager-spot' image
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/image-builder:20240419-900b623-gcloud-425
+        args:
+        # Wrap the release script with the runner so we can use docker-in-docker
+        - runner
+        - images/image-builder-script/builder.sh
+        - images/prow-controller-manager-spot
+        - --confirm=true
+        resources:
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+
   - name: post-testing-push-make-dind
     cluster: prow-trusted
     run_if_changed: '^images/make-dind/'

--- a/images/prow-controller-manager-spot/Dockerfile
+++ b/images/prow-controller-manager-spot/Dockerfile
@@ -1,0 +1,33 @@
+# Copyright 2023 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BUILDER_IMAGE
+ARG BASE_IMAGE
+
+FROM ${BUILDER_IMAGE} as builder
+
+WORKDIR /workspace
+
+RUN git clone --depth=1 --branch option_recreate_prowjob_on_termination https://github.com/inteon/prow.git
+RUN cd ./prow/ && CGO_ENABLED=0 go build -o ../prow-controller-manager ./cmd/prow-controller-manager/.
+
+FROM ${BASE_IMAGE}
+LABEL maintainer="cert-manager-maintainers@googlegroups.com"
+
+WORKDIR /
+COPY --from=builder /workspace/prow-controller-manager /prow-controller-manager
+
+USER 65532:65532
+
+ENTRYPOINT ["/prow-controller-manager"]

--- a/images/prow-controller-manager-spot/README.md
+++ b/images/prow-controller-manager-spot/README.md
@@ -1,0 +1,4 @@
+# prow-controller-manager with support for spot instances
+
+This is a build of prow-controller-manager that includes the changes in this PR: https://github.com/kubernetes-sigs/prow/pull/117
+The goal is to switch to the upstream version once that PR is merged.

--- a/images/prow-controller-manager-spot/build.yaml
+++ b/images/prow-controller-manager-spot/build.yaml
@@ -1,0 +1,12 @@
+name: prow-controller-manager-spot # Name of the image to be built
+
+variants:
+  latest:
+    arguments:
+      BUILDER_IMAGE: "europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240419-532d563-1.22"
+      BASE_IMAGE: "quay.io/jetstack/base-static@sha256:ba3cff0a4cacc5ae564e04c1f645000e8c9234c0f4b09534be1dee7874a42141"
+
+# Image names to be tagged and pushed
+images:
+- ${_REGISTRY}/${_NAME}:${_DATE_STAMP}-${_GIT_REF}
+- ${_REGISTRY}/${_NAME}:latest

--- a/prow/cluster/prow_controller_manager_deployment.yaml
+++ b/prow/cluster/prow_controller_manager_deployment.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20240419-d3bf92f82
+        image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/prow-controller-manager-spot:20240420-4c90c7c-dirty
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false


### PR DESCRIPTION
Add prow-controller-manager image that includes changes from PR https://github.com/kubernetes-sigs/prow/pull/117.