### PR TITLE
Restrict branchprotection branches, which are regexes

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -66,9 +66,9 @@ branch-protection:
         contexts:
         - dco
       include:
-        - main
-        - master
-        - release-.*
+        - ^main$
+        - ^master$
+        - ^release-.*$
       repos:
         api:
           protect: false


### PR DESCRIPTION
The branch protection include `main` also included branches named `self-upgrade-main`.
This is unintentional and can be fixed by adding ^ and $ to the start and end of the regex.