### PR TITLE
Run gencred less frequently since it causes prow components to restart

### DIFF
--- a/config/gencred-config/gencred-config.yaml
+++ b/config/gencred-config/gencred-config.yaml
@@ -1,14 +1,14 @@
 clusters:
 - gke: projects/cert-manager-tests-trusted/locations/europe-west1-b/clusters/prow-trusted
   name: prow-trusted
-  duration: 3h
+  duration: 48h
   kubernetesSecret:
     name: kubeconfig-prow-trusted
     namespace: default
 
 - gke: projects/cert-manager-tests-untrusted/locations/europe-west1-b/clusters/prow-untrusted
   name: default
-  duration: 3h
+  duration: 48h
   kubernetesSecret:
     name: kubeconfig-prow-untrusted
     namespace: default

--- a/prow/cluster/gencred_deployment.yaml
+++ b/prow/cluster/gencred_deployment.yaml
@@ -41,7 +41,7 @@ spec:
         image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/gencred:20240419-900b623
         args:
         - --config=/etc/config/gencred-config.yaml
-        - --refresh-interval=2h
+        - --refresh-interval=46h
         ports:
         - name: metrics
           containerPort: 9090


### PR DESCRIPTION
Every time that gencred renews its jwt tokens, all components that have this token mounted restart.
This is because they detected a change and want to load the new token (no dynamic loader seems to be implemented by prow yet).
To reduce the amount of restarts, I propose to make the jwts last longer and refresh them less frequently.