### PR TITLE
Apply fixes for things we missed in #1008

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -102,7 +102,7 @@ branch-protection:
             master:
               required_status_checks:
                 contexts:
-                - pull-cert-manager-master-chart
+                - pull-cert-manager-master-make-verify
                 - pull-cert-manager-master-make-test
                 - pull-cert-manager-master-e2e-v1-28
                 - pull-cert-manager-master-e2e-v1-28-upgrade

--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -23,7 +23,7 @@ presubmits:
         - make
         - -j2
         - vendor-go
-        - verify
+        - ci-presubmit
         resources:
           requests:
             cpu: 2000m

--- a/config/prowgen/pkg/generators.go
+++ b/config/prowgen/pkg/generators.go
@@ -76,7 +76,7 @@ func MakeVerify(ctx *ProwContext) *Job {
 				"make",
 				makeJobs,
 				"vendor-go",
-				"verify",
+				"ci-presubmit",
 			},
 			Resources: ContainerResources{
 				Requests: ContainerResourceRequest{


### PR DESCRIPTION
In #1008, we split the tests in `make-verify` and `make-test`.
However, there are two issues we found after applying these changes:
- 1. the `verify` make target is not optimised for running in parallel (yet)
    - replace `verify` target with `ci-presubmit`, which we can tune more freely to fix any issues
- 2. the `pull-cert-manager-master-chart` status check is still expected to be present
    - update the branch protection rules in the config.yaml file

This PR fixes both issues.