### PR TITLE
Fix k8s test versions for all supported cert-manager releases

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -70,108 +70,6 @@ presubmits:
     - master
     always_run: true
     optional: false
-  - name: pull-cert-manager-master-e2e-v1-23
-    max_concurrency: 4
-    decorate: true
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
-      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-      testgrid-create-job-group: "true"
-      testgrid-dashboards: cert-manager-presubmits-master
-    labels:
-      preset-cloudflare-credentials: "true"
-      preset-dind-enabled: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-go-cache: "true"
-      preset-local-cache: "true"
-      preset-retry-flakey-jobs: "true"
-    spec:
-      containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-        args:
-        - runner
-        - make
-        - -j7
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.23
-        resources:
-          requests:
-            cpu: 7000m
-            memory: 6Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
-      dnsPolicy: None
-      dnsConfig:
-        nameservers:
-        - 8.8.8.8
-        - 8.8.4.4
-    branches:
-    - master
-    always_run: false
-    optional: true
-  - name: pull-cert-manager-master-e2e-v1-24
-    max_concurrency: 4
-    decorate: true
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
-      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-      testgrid-create-job-group: "true"
-      testgrid-dashboards: cert-manager-presubmits-master
-    labels:
-      preset-cloudflare-credentials: "true"
-      preset-dind-enabled: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-go-cache: "true"
-      preset-local-cache: "true"
-      preset-retry-flakey-jobs: "true"
-    spec:
-      containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-        args:
-        - runner
-        - make
-        - -j7
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.24
-        resources:
-          requests:
-            cpu: 7000m
-            memory: 6Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
-      dnsPolicy: None
-      dnsConfig:
-        nameservers:
-        - 8.8.8.8
-        - 8.8.4.4
-    branches:
-    - master
-    always_run: false
-    optional: true
   - name: pull-cert-manager-master-e2e-v1-25
     max_concurrency: 4
     decorate: true
@@ -325,6 +223,57 @@ presubmits:
     - master
     always_run: false
     optional: true
+  - name: pull-cert-manager-master-e2e-v1-28
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.28 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-job-group: "true"
+      testgrid-dashboards: cert-manager-presubmits-master
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.28
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - master
+    always_run: false
+    optional: true
   - name: pull-cert-manager-master-e2e-v1-29
     max_concurrency: 4
     decorate: true
@@ -376,11 +325,11 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-28
+  - name: pull-cert-manager-master-e2e-v1-30
     max_concurrency: 4
     decorate: true
     annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.28 cluster
+      description: Runs the end-to-end test suite against a Kubernetes v1.30 cluster
       testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
       testgrid-create-job-group: "true"
       testgrid-dashboards: cert-manager-presubmits-master
@@ -401,7 +350,7 @@ presubmits:
         - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.28
+        - K8S_VERSION=1.30
         resources:
           requests:
             cpu: 7000m
@@ -427,7 +376,7 @@ presubmits:
     - master
     always_run: true
     optional: false
-  - name: pull-cert-manager-master-e2e-v1-28-upgrade
+  - name: pull-cert-manager-master-e2e-v1-30-upgrade
     max_concurrency: 4
     decorate: true
     annotations:
@@ -445,7 +394,7 @@ presubmits:
         args:
         - runner
         - make
-        - K8S_VERSION=1.28
+        - K8S_VERSION=1.30
         - vendor-go
         - test-upgrade
         resources:
@@ -500,7 +449,7 @@ presubmits:
     always_run: false
     optional: true
     run_if_changed: go.mod
-  - name: pull-cert-manager-master-e2e-v1-28-issuers-venafi-tpp
+  - name: pull-cert-manager-master-e2e-v1-30-issuers-venafi-tpp
     max_concurrency: 4
     decorate: true
     annotations:
@@ -524,7 +473,7 @@ presubmits:
         - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.28
+        - K8S_VERSION=1.30
         resources:
           requests:
             cpu: 7000m
@@ -550,7 +499,7 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-28-issuers-venafi-cloud
+  - name: pull-cert-manager-master-e2e-v1-30-issuers-venafi-cloud
     max_concurrency: 4
     decorate: true
     annotations:
@@ -574,7 +523,7 @@ presubmits:
         - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.28
+        - K8S_VERSION=1.30
         resources:
           requests:
             cpu: 7000m
@@ -600,7 +549,7 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-28-feature-gates-disabled
+  - name: pull-cert-manager-master-e2e-v1-30-feature-gates-disabled
     max_concurrency: 4
     decorate: true
     annotations:
@@ -625,7 +574,7 @@ presubmits:
         - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.28
+        - K8S_VERSION=1.30
         resources:
           requests:
             cpu: 7000m
@@ -651,7 +600,7 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-28-bestpractice-install
+  - name: pull-cert-manager-master-e2e-v1-30-bestpractice-install
     max_concurrency: 4
     decorate: true
     annotations:
@@ -678,7 +627,7 @@ presubmits:
         - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.28
+        - K8S_VERSION=1.30
         resources:
           requests:
             cpu: 7000m
@@ -739,110 +688,6 @@ periodics:
     repo: cert-manager
     base_ref: master
   cron: 00 00-23/02 * * *
-- name: ci-cert-manager-master-e2e-v1-23
-  max_concurrency: 4
-  decorate: true
-  annotations:
-    description: Runs the end-to-end test suite against a Kubernetes v1.23 cluster
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-master
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-dind-enabled: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-go-cache: "true"
-    preset-local-cache: "true"
-    preset-retry-flakey-jobs: "true"
-  spec:
-    containers:
-    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-      args:
-      - runner
-      - make
-      - -j7
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.23
-      resources:
-        requests:
-          cpu: 7000m
-          memory: 6Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsPolicy: None
-    dnsConfig:
-      nameservers:
-      - 8.8.8.8
-      - 8.8.4.4
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  cron: 03 01-23/02 * * *
-- name: ci-cert-manager-master-e2e-v1-24
-  max_concurrency: 4
-  decorate: true
-  annotations:
-    description: Runs the end-to-end test suite against a Kubernetes v1.24 cluster
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-master
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-dind-enabled: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-go-cache: "true"
-    preset-local-cache: "true"
-    preset-retry-flakey-jobs: "true"
-  spec:
-    containers:
-    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-      args:
-      - runner
-      - make
-      - -j7
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.24
-      resources:
-        requests:
-          cpu: 7000m
-          memory: 6Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsPolicy: None
-    dnsConfig:
-      nameservers:
-      - 8.8.8.8
-      - 8.8.4.4
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  cron: 06 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-25
   max_concurrency: 4
   decorate: true
@@ -894,7 +739,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 09 01-23/02 * * *
+  cron: 03 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-26
   max_concurrency: 4
   decorate: true
@@ -946,7 +791,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 12 00-23/02 * * *
+  cron: 06 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-27
   max_concurrency: 4
   decorate: true
@@ -998,59 +843,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 15 01-23/02 * * *
-- name: ci-cert-manager-master-e2e-v1-29
-  max_concurrency: 4
-  decorate: true
-  annotations:
-    description: Runs the end-to-end test suite against a Kubernetes v1.29 cluster
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-master
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-dind-enabled: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-go-cache: "true"
-    preset-local-cache: "true"
-    preset-retry-flakey-jobs: "true"
-  spec:
-    containers:
-    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-      args:
-      - runner
-      - make
-      - -j7
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.29
-      resources:
-        requests:
-          cpu: 7000m
-          memory: 6Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsPolicy: None
-    dnsConfig:
-      nameservers:
-      - 8.8.8.8
-      - 8.8.4.4
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  cron: 18 00-23/02 * * *
+  cron: 09 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-28
   max_concurrency: 4
   decorate: true
@@ -1102,23 +895,23 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 21 01-23/02 * * *
-- name: ci-cert-manager-master-e2e-v1-28-issuers-venafi
+  cron: 12 00-23/02 * * *
+- name: ci-cert-manager-master-e2e-v1-29
   max_concurrency: 4
   decorate: true
   annotations:
-    description: Runs Venafi (VaaS and TPP) e2e tests
+    description: Runs the end-to-end test suite against a Kubernetes v1.29 cluster
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-master
   labels:
+    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
-    preset-ginkgo-focus-venafi: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
     preset-retry-flakey-jobs: "true"
-    preset-venafi-cloud-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1128,7 +921,7 @@ periodics:
       - -j7
       - vendor-go
       - e2e-ci
-      - K8S_VERSION=1.28
+      - K8S_VERSION=1.29
       resources:
         requests:
           cpu: 7000m
@@ -1154,8 +947,112 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 24 00-23/12 * * *
-- name: ci-cert-manager-master-e2e-v1-28-upgrade
+  cron: 15 01-23/02 * * *
+- name: ci-cert-manager-master-e2e-v1-30
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.30 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-master
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.30
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  cron: 18 00-23/02 * * *
+- name: ci-cert-manager-master-e2e-v1-30-issuers-venafi
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs Venafi (VaaS and TPP) e2e tests
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-master
+  labels:
+    preset-dind-enabled: "true"
+    preset-ginkgo-focus-venafi: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-venafi-cloud-credentials: "true"
+    preset-venafi-tpp-credentials: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.30
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  cron: 21 00-23/12 * * *
+- name: ci-cert-manager-master-e2e-v1-30-upgrade
   max_concurrency: 4
   decorate: true
   annotations:
@@ -1173,7 +1070,7 @@ periodics:
       args:
       - runner
       - make
-      - K8S_VERSION=1.28
+      - K8S_VERSION=1.30
       - vendor-go
       - test-upgrade
       resources:
@@ -1194,8 +1091,8 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 27 00-23/08 * * *
-- name: ci-cert-manager-master-e2e-v1-28-bestpractice-install
+  cron: 24 00-23/08 * * *
+- name: ci-cert-manager-master-e2e-v1-30-bestpractice-install
   max_concurrency: 4
   decorate: true
   annotations:
@@ -1222,7 +1119,7 @@ periodics:
       - -j7
       - vendor-go
       - e2e-ci
-      - K8S_VERSION=1.28
+      - K8S_VERSION=1.30
       resources:
         requests:
           cpu: 7000m
@@ -1248,111 +1145,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 30 00-23/24 * * *
-- name: ci-cert-manager-master-e2e-v1-23-feature-gates-disabled
-  max_concurrency: 4
-  decorate: true
-  annotations:
-    description: Runs the E2E tests with all feature gates disabled
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-master
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-dind-enabled: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-go-cache: "true"
-    preset-local-cache: "true"
-    preset-retry-flakey-jobs: "true"
-  spec:
-    containers:
-    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-      args:
-      - runner
-      - make
-      - -j7
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.23
-      resources:
-        requests:
-          cpu: 7000m
-          memory: 6Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsPolicy: None
-    dnsConfig:
-      nameservers:
-      - 8.8.8.8
-      - 8.8.4.4
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  cron: 33 07-23/24 * * *
-- name: ci-cert-manager-master-e2e-v1-24-feature-gates-disabled
-  max_concurrency: 4
-  decorate: true
-  annotations:
-    description: Runs the E2E tests with all feature gates disabled
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-master
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-dind-enabled: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-go-cache: "true"
-    preset-local-cache: "true"
-    preset-retry-flakey-jobs: "true"
-  spec:
-    containers:
-    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-      args:
-      - runner
-      - make
-      - -j7
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.24
-      resources:
-        requests:
-          cpu: 7000m
-          memory: 6Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsPolicy: None
-    dnsConfig:
-      nameservers:
-      - 8.8.8.8
-      - 8.8.4.4
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  cron: 36 14-23/24 * * *
+  cron: 27 00-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-25-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1404,7 +1197,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 39 21-23/24 * * *
+  cron: 30 07-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-26-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1456,7 +1249,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 42 04-23/24 * * *
+  cron: 33 14-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-27-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1508,59 +1301,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 45 11-23/24 * * *
-- name: ci-cert-manager-master-e2e-v1-29-feature-gates-disabled
-  max_concurrency: 4
-  decorate: true
-  annotations:
-    description: Runs the E2E tests with all feature gates disabled
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-master
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-dind-enabled: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-go-cache: "true"
-    preset-local-cache: "true"
-    preset-retry-flakey-jobs: "true"
-  spec:
-    containers:
-    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-      args:
-      - runner
-      - make
-      - -j7
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.29
-      resources:
-        requests:
-          cpu: 7000m
-          memory: 6Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsPolicy: None
-    dnsConfig:
-      nameservers:
-      - 8.8.8.8
-      - 8.8.4.4
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  cron: 48 18-23/24 * * *
+  cron: 36 21-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-28-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1612,7 +1353,111 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 51 01-23/24 * * *
+  cron: 39 04-23/24 * * *
+- name: ci-cert-manager-master-e2e-v1-29-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-master
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.29
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  cron: 42 11-23/24 * * *
+- name: ci-cert-manager-master-e2e-v1-30-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-master
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.30
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  cron: 45 18-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-controller
   max_concurrency: 2
   decorate: true
@@ -1651,7 +1496,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 54 08-23/24 * * *
+  cron: 48 01-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-acmesolver
   max_concurrency: 2
   decorate: true
@@ -1690,7 +1535,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 57 15-23/24 * * *
+  cron: 51 08-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-startupapicheck
   max_concurrency: 2
   decorate: true
@@ -1729,7 +1574,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 00 22-23/24 * * *
+  cron: 54 15-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-cainjector
   max_concurrency: 2
   decorate: true
@@ -1768,7 +1613,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 03 05-23/24 * * *
+  cron: 57 22-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-webhook
   max_concurrency: 2
   decorate: true
@@ -1807,4 +1652,4 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 06 12-23/24 * * *
+  cron: 00 05-23/24 * * *

--- a/config/jobs/cert-manager/cert-manager/release-1.12/cert-manager-release-1.12.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.12/cert-manager-release-1.12.yaml
@@ -307,6 +307,102 @@ presubmits:
     - release-1.12
     always_run: false
     optional: true
+  - name: pull-cert-manager-release-1.12-e2e-v1-28
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.28 cluster
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.28
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - release-1.12
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.12-e2e-v1-29
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.29 cluster
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.29
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - release-1.12
+    always_run: false
+    optional: true
   - name: pull-cert-manager-release-1.12-e2e-v1-27
     max_concurrency: 4
     decorate: true
@@ -910,6 +1006,110 @@ periodics:
     repo: cert-manager
     base_ref: release-1.12
   cron: 16 00-23/02 * * *
+- name: ci-cert-manager-release-1.12-e2e-v1-28
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.28 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.12
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.28
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.12
+  cron: 19 01-23/02 * * *
+- name: ci-cert-manager-release-1.12-e2e-v1-29
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.29 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.12
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.29
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.12
+  cron: 22 00-23/02 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-27
   max_concurrency: 4
   decorate: true
@@ -961,7 +1161,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 19 01-23/02 * * *
+  cron: 25 01-23/02 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-27-issuers-venafi
   max_concurrency: 4
   decorate: true
@@ -1013,7 +1213,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 22 01-23/12 * * *
+  cron: 28 01-23/12 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-27-upgrade
   max_concurrency: 4
   decorate: true
@@ -1053,7 +1253,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 25 01-23/08 * * *
+  cron: 31 01-23/08 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-27-bestpractice-install
   max_concurrency: 4
   decorate: true
@@ -1107,7 +1307,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 28 01-23/24 * * *
+  cron: 34 01-23/24 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-22-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1159,7 +1359,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 31 08-23/24 * * *
+  cron: 37 08-23/24 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-23-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1211,7 +1411,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 34 15-23/24 * * *
+  cron: 40 15-23/24 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-24-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1263,7 +1463,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 37 22-23/24 * * *
+  cron: 43 22-23/24 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-25-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1315,7 +1515,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 40 05-23/24 * * *
+  cron: 46 05-23/24 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-26-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1367,7 +1567,111 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 43 12-23/24 * * *
+  cron: 49 12-23/24 * * *
+- name: ci-cert-manager-release-1.12-e2e-v1-28-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.12
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.28
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.12
+  cron: 52 19-23/24 * * *
+- name: ci-cert-manager-release-1.12-e2e-v1-29-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.12
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.29
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.12
+  cron: 55 02-23/24 * * *
 - name: ci-cert-manager-release-1.12-e2e-v1-27-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1419,7 +1723,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 46 19-23/24 * * *
+  cron: 58 09-23/24 * * *
 - name: ci-cert-manager-release-1.12-trivy-test-controller
   max_concurrency: 2
   decorate: true
@@ -1458,7 +1762,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 49 02-23/24 * * *
+  cron: 01 16-23/24 * * *
 - name: ci-cert-manager-release-1.12-trivy-test-acmesolver
   max_concurrency: 2
   decorate: true
@@ -1497,7 +1801,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 52 09-23/24 * * *
+  cron: 04 23-23/24 * * *
 - name: ci-cert-manager-release-1.12-trivy-test-ctl
   max_concurrency: 2
   decorate: true
@@ -1536,7 +1840,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 55 16-23/24 * * *
+  cron: 07 06-23/24 * * *
 - name: ci-cert-manager-release-1.12-trivy-test-cainjector
   max_concurrency: 2
   decorate: true
@@ -1575,7 +1879,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 58 23-23/24 * * *
+  cron: 10 13-23/24 * * *
 - name: ci-cert-manager-release-1.12-trivy-test-webhook
   max_concurrency: 2
   decorate: true
@@ -1614,4 +1918,4 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.12
-  cron: 01 06-23/24 * * *
+  cron: 13 20-23/24 * * *

--- a/config/jobs/cert-manager/cert-manager/release-1.13/cert-manager-release-1.13.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.13/cert-manager-release-1.13.yaml
@@ -307,6 +307,54 @@ presubmits:
     - release-1.13
     always_run: false
     optional: true
+  - name: pull-cert-manager-release-1.13-e2e-v1-29
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.29 cluster
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.29
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - release-1.13
+    always_run: false
+    optional: true
   - name: pull-cert-manager-release-1.13-e2e-v1-28
     max_concurrency: 4
     decorate: true
@@ -910,6 +958,58 @@ periodics:
     repo: cert-manager
     base_ref: release-1.13
   cron: 17 01-23/02 * * *
+- name: ci-cert-manager-release-1.13-e2e-v1-29
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.29 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.29
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  cron: 20 00-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-28
   max_concurrency: 4
   decorate: true
@@ -961,7 +1061,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 20 00-23/02 * * *
+  cron: 23 01-23/02 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-28-issuers-venafi
   max_concurrency: 4
   decorate: true
@@ -1013,7 +1113,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 23 02-23/12 * * *
+  cron: 26 02-23/12 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-28-upgrade
   max_concurrency: 4
   decorate: true
@@ -1053,7 +1153,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 26 02-23/08 * * *
+  cron: 29 02-23/08 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-28-bestpractice-install
   max_concurrency: 4
   decorate: true
@@ -1107,7 +1207,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 29 02-23/24 * * *
+  cron: 32 02-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-23-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1159,7 +1259,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 32 09-23/24 * * *
+  cron: 35 09-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-24-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1211,7 +1311,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 35 16-23/24 * * *
+  cron: 38 16-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-25-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1263,7 +1363,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 38 23-23/24 * * *
+  cron: 41 23-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-26-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1315,7 +1415,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 41 06-23/24 * * *
+  cron: 44 06-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-27-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1367,7 +1467,59 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 44 13-23/24 * * *
+  cron: 47 13-23/24 * * *
+- name: ci-cert-manager-release-1.13-e2e-v1-29-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.13
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.29
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.13
+  cron: 50 20-23/24 * * *
 - name: ci-cert-manager-release-1.13-e2e-v1-28-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1419,7 +1571,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 47 20-23/24 * * *
+  cron: 53 03-23/24 * * *
 - name: ci-cert-manager-release-1.13-trivy-test-controller
   max_concurrency: 2
   decorate: true
@@ -1458,7 +1610,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 50 03-23/24 * * *
+  cron: 56 10-23/24 * * *
 - name: ci-cert-manager-release-1.13-trivy-test-acmesolver
   max_concurrency: 2
   decorate: true
@@ -1497,7 +1649,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 53 10-23/24 * * *
+  cron: 59 17-23/24 * * *
 - name: ci-cert-manager-release-1.13-trivy-test-ctl
   max_concurrency: 2
   decorate: true
@@ -1536,7 +1688,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 56 17-23/24 * * *
+  cron: 02 00-23/24 * * *
 - name: ci-cert-manager-release-1.13-trivy-test-cainjector
   max_concurrency: 2
   decorate: true
@@ -1575,7 +1727,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 59 00-23/24 * * *
+  cron: 05 07-23/24 * * *
 - name: ci-cert-manager-release-1.13-trivy-test-webhook
   max_concurrency: 2
   decorate: true
@@ -1614,4 +1766,4 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.13
-  cron: 02 07-23/24 * * *
+  cron: 08 14-23/24 * * *

--- a/config/prowgen/prowspecs/specs.go
+++ b/config/prowgen/prowspecs/specs.go
@@ -49,7 +49,7 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 		},
 
 		primaryKubernetesVersion: "1.27",
-		otherKubernetesVersions:  []string{"1.22", "1.23", "1.24", "1.25", "1.26"},
+		otherKubernetesVersions:  []string{"1.22", "1.23", "1.24", "1.25", "1.26", "1.28", "1.29"},
 
 		e2eCPURequest:    "7000m",
 		e2eMemoryRequest: "6Gi",
@@ -76,7 +76,7 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 		},
 
 		primaryKubernetesVersion: "1.28",
-		otherKubernetesVersions:  []string{"1.23", "1.24", "1.25", "1.26", "1.27"},
+		otherKubernetesVersions:  []string{"1.23", "1.24", "1.25", "1.26", "1.27", "1.29"},
 
 		e2eCPURequest:    "7000m",
 		e2eMemoryRequest: "6Gi",
@@ -129,8 +129,8 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 			Repo: "cert-manager",
 		},
 
-		primaryKubernetesVersion: "1.28",
-		otherKubernetesVersions:  []string{"1.23", "1.24", "1.25", "1.26", "1.27", "1.29"},
+		primaryKubernetesVersion: "1.30",
+		otherKubernetesVersions:  []string{"1.25", "1.26", "1.27", "1.28", "1.29"},
 
 		e2eCPURequest:    "7000m",
 		e2eMemoryRequest: "6Gi",


### PR DESCRIPTION
See https://github.com/cert-manager/website/pull/1478 for compatibility based on kind versions

Summary of changes:

1. Test 1.28 and 1.29 for cert-manager 1.12
2. Test 1.29 for cert-manager 1.13
3. Remove old unsupported k8s versions on master
4. Test master with v1.30 as the primary version