### PR TITLE
Bump version of prow-controller-manager-spot

### DIFF
--- a/prow/cluster/prow_controller_manager_deployment.yaml
+++ b/prow/cluster/prow_controller_manager_deployment.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/prow-controller-manager-spot:20240420-4c90c7c-dirty
+        image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/prow-controller-manager-spot:20240613-2e014f3
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false


### PR DESCRIPTION
Already applied to cluster (using `cd prow/ && make deploy-prow`)