### PR TITLE
Bump go version for webhook-example presubmit job

### DIFF
--- a/config/jobs/cert-manager/webhook-example/cert-manager-webhook-example-presubmits.yaml
+++ b/config/jobs/cert-manager/webhook-example/cert-manager-webhook-example-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: golang:1.20-buster
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240422-729441b-1.22
         args:
         - make
         - test


### PR DESCRIPTION
I replaced the go image with the `golang-dind` image that we use for our other tests.