### PR TITLE
Rename required GH status for website PRs

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -109,7 +109,7 @@ branch-protection:
         website:
           required_status_checks:
             contexts:
-            - netlify/cert-manager-website/deploy-preview # See https://github.com/cert-manager/infrastructure#netlify
+            - netlify/cert-manager/deploy-preview # See https://github.com/cert-manager/infrastructure#netlify
             - pull-cert-manager-website-verify
         webhook-example:
           required_status_checks:


### PR DESCRIPTION
Now that we unified and moved the cert-manager.io Netlify setup to the CNCF Netlify account, the GH status that checks that the preview was deployed correctly has a different name.

Currently, we have two statuses:
![image](https://github.com/cert-manager/testing/assets/42113979/a308cff9-f097-4b8c-aefd-a036f2721a10)

The goal is to only have one status `netlify/cert-manager/deploy-preview` and have that status as the required status.