### PR TITLE
Add the "gateway-shim" label

### DIFF
--- a/config/labels.yaml
+++ b/config/labels.yaml
@@ -78,6 +78,11 @@ repos:
       target: both
       addedBy: prow
     - color: 0052cc
+      description: Indicates a PR or issue relates to the gateway-shim feature (as in Gateway API).
+      name: area/gateway-shim
+      target: both
+      addedBy: prow
+    - color: 0052cc
       description: Indicates a PR or issue relates to the cert-manager-ctl CLI component
       name: area/ctl
       target: both


### PR DESCRIPTION
I propose to add a new label for the Gateway shim feature. Example of issue I'd like to tag it with: https://github.com/cert-manager/cert-manager/issues/7176

How does one re-deploy Prow after that though? 😅