### PR TITLE
Remove unused K8S_VERSION environment variable from istio-csr tests

### DIFF
--- a/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
+++ b/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
@@ -107,8 +107,7 @@ presubmits:
         - 8.8.8.8
         - 8.8.4.4
 
-  # kind based istio-csr e2e job for Kubernetes v1.26, istio v1.14
-  - name: pull-cert-manager-istio-csr-k8s-v1-26-istio-v1-14
+  - name: pull-cert-manager-istio-csr-istio-v1-14
     decorate: true
     always_run: true
     labels:
@@ -128,8 +127,6 @@ presubmits:
             cpu: 3500m
             memory: 6Gi
         env:
-        - name: K8S_VERSION
-          value: "1.26.1"
         - name: ISTIO_VERSION
           value: "1.14.6"
         securityContext:
@@ -142,8 +139,7 @@ presubmits:
         - 8.8.8.8
         - 8.8.4.4
 
-  # kind based istio-csr e2e job for Kubernetes v1.26, istio v1.15
-  - name: pull-cert-manager-istio-csr-k8s-v1-26-istio-v1-15
+  - name: pull-cert-manager-istio-csr-istio-v1-15
     decorate: true
     always_run: true
     labels:
@@ -163,8 +159,6 @@ presubmits:
             cpu: 3500m
             memory: 6Gi
         env:
-        - name: K8S_VERSION
-          value: "1.26.1"
         - name: ISTIO_VERSION
           value: "1.15.5"
         securityContext:
@@ -177,8 +171,7 @@ presubmits:
         - 8.8.8.8
         - 8.8.4.4
 
-  # kind based istio-csr e2e job for Kubernetes v1.26, istio v1.16
-  - name: pull-cert-manager-istio-csr-k8s-v1-26-istio-v1-16
+  - name: pull-cert-manager-istio-csr-istio-v1-16
     decorate: true
     always_run: true
     labels:
@@ -198,8 +191,6 @@ presubmits:
             cpu: 3500m
             memory: 6Gi
         env:
-        - name: K8S_VERSION
-          value: "1.26.1"
         - name: ISTIO_VERSION
           value: "1.16.7"
         securityContext:
@@ -212,8 +203,7 @@ presubmits:
         - 8.8.8.8
         - 8.8.4.4
 
-  # kind based istio-csr e2e job for Kubernetes v1.26, istio v1.17
-  - name: pull-cert-manager-istio-csr-k8s-v1-26-istio-v1-17
+  - name: pull-cert-manager-istio-csr-istio-v1-17
     decorate: true
     always_run: true
     labels:
@@ -233,8 +223,6 @@ presubmits:
             cpu: 3500m
             memory: 6Gi
         env:
-        - name: K8S_VERSION
-          value: "1.26.1"
         - name: ISTIO_VERSION
           value: "1.17.8"
         securityContext:
@@ -247,8 +235,7 @@ presubmits:
         - 8.8.8.8
         - 8.8.4.4
 
-  # kind based istio-csr e2e job for Kubernetes v1.26, istio v1.18
-  - name: pull-cert-manager-istio-csr-k8s-v1-26-istio-v1-18
+  - name: pull-cert-manager-istio-csr-istio-v1-18
     decorate: true
     always_run: true
     labels:
@@ -268,8 +255,6 @@ presubmits:
             cpu: 3500m
             memory: 6Gi
         env:
-        - name: K8S_VERSION
-          value: "1.26.1"
         - name: ISTIO_VERSION
           value: "1.18.7"
         securityContext:
@@ -282,8 +267,7 @@ presubmits:
         - 8.8.8.8
         - 8.8.4.4
 
-  # kind based istio-csr e2e job for Kubernetes v1.26, istio v1.17
-  - name: pull-cert-manager-istio-csr-k8s-v1-26-istio-v1-19
+  - name: pull-cert-manager-istio-csr-istio-v1-19
     decorate: true
     always_run: true
     labels:
@@ -303,8 +287,6 @@ presubmits:
             cpu: 3500m
             memory: 6Gi
         env:
-        - name: K8S_VERSION
-          value: "1.26.1"
         - name: ISTIO_VERSION
           value: "1.19.6"
         securityContext:
@@ -317,8 +299,7 @@ presubmits:
         - 8.8.8.8
         - 8.8.4.4
 
-  # kind based istio-csr e2e job for Kubernetes v1.29, istio v1.20
-  - name: pull-cert-manager-istio-csr-k8s-v1-29-istio-v1-20
+  - name: pull-cert-manager-istio-csr-istio-v1-20
     decorate: true
     always_run: true
     labels:
@@ -338,8 +319,6 @@ presubmits:
             cpu: 3500m
             memory: 6Gi
         env:
-        - name: K8S_VERSION
-          value: "1.29.1"
         - name: ISTIO_VERSION
           value: "1.20.2"
         securityContext:


### PR DESCRIPTION
Currently, the K8S_VERSION environment variable is ignored when running istio-csr tests.
To avoid confusion, I propose to not set the variable in the tests and rename the tests so it is clear they all just use the kubernetes version defined in the repo.

We might want to add support for configurable K8S_VERSION in the future. The K8S_VERSION defined today are however just random and unuseful.