### PR TITLE
Add skip-review label to label-sync config

### DIFF
--- a/config/labels.yaml
+++ b/config/labels.yaml
@@ -404,3 +404,8 @@ default:
     name: spam
     target: prs
     addedBy: member or author
+  - color: 0ffa16
+    description: Indicates a PR is trusted, used by tide for auto-merging PRs.
+    name: skip-review
+    target: prs
+    addedBy: autobump bot


### PR DESCRIPTION
Based on https://github.com/kubernetes/test-infra/blob/f4dfb8f3f0062895f1d66a659f52c91409c45ef9/label_sync/labels.yaml#L1109-L1113

This will add the label to the known labels on all repositories.