### PR TITLE
Auto-run tests on PRs created by github-actions

### DIFF
--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -4,13 +4,9 @@
 ---
 triggers:
 - repos:
-  - cert-manager/testing
-  - cert-manager/cert-manager
-  - cert-manager/website
-  - cert-manager/trust-manager
-  - cert-manager/issuer-lib
-  - cert-manager/helm-tool
-  - cert-manager/cmctl
+  - cert-manager
+  trusted_apps:
+  - github-actions
   only_org_members: true
 
 blunderbuss:


### PR DESCRIPTION
Add `github-actions` to the list of `trusted_apps`, such that tests are run automatically.

Also simplifies the `repos` section of the triggers configuration.

Worked for https://github.com/cert-manager/approver-policy/pull/468.