### PR TITLE
Add istio-csr test for pure runtime configuration

### DIFF
--- a/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
+++ b/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
@@ -107,6 +107,36 @@ presubmits:
         - 8.8.8.8
         - 8.8.4.4
 
+  - name: pull-cert-manager-istio-csr-pure-runtime-config
+    decorate: true
+    always_run: true
+    labels:
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - vendor-go
+        - test-e2e-pure-runtime
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+
+
   - name: pull-cert-manager-istio-csr-istio-v1-17
     decorate: true
     always_run: true


### PR DESCRIPTION
A new e2e test was added in https://github.com/cert-manager/istio-csr/pull/359 - this commit adds the e2e test as a presubmit.