### PR TITLE
Add note explaining where a required check is defined

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -110,6 +110,10 @@ branch-protection:
           required_status_checks:
             contexts:
             - netlify/cert-manager/deploy-preview # See https://github.com/cert-manager/infrastructure#netlify
+            # NB: "pull-cert-manager-website-verify" used to be a standard Prow presubmit, similar to other
+            # presubmits required in this file.
+            # It's now a GitHub Action with the same name, defined in the cert-manager/website repo; see e.g.
+            # https://github.com/cert-manager/website/blob/6ec7f87093a3e36828453ad15db89e7c7970ba3a/.github/workflows/check.yaml#L8
             - pull-cert-manager-website-verify
         webhook-example:
           required_status_checks:


### PR DESCRIPTION
In https://github.com/cert-manager/testing/pull/789 we removed the presubmit from this repo, but the test is
still marked as required for the website repo.

This test is defined in the website repo instead.