### PR TITLE
Fix incorrect http01 acme solver configuration

### DIFF
--- a/prow/cluster/gateway.yaml
+++ b/prow/cluster/gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   name: prow-gateway
   namespace: default
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/issuer: letsencrypt-prod
     cert-manager.io/issue-temporary-certificate: "true"
 spec:
   gatewayClassName: gke-l7-global-external-managed

--- a/prow/cluster/letsencrypt-prod-issuer.yaml
+++ b/prow/cluster/letsencrypt-prod-issuer.yaml
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
+kind: Issuer
 metadata:
   name: letsencrypt-prod
+  namespace: default
 spec:
   acme:
     server: https://acme-v02.api.letsencrypt.org/directory
@@ -23,6 +24,10 @@ spec:
       name: letsencrypt-prod-issuer-account-key
     solvers:
     - http01:
-        ingress:
-          ingressClassName: prod-nginx
+        gatewayHTTPRoute:
+          serviceType: ClusterIP
+          parentRefs:
+            - name: prow-gateway
+              namespace: default
+              kind: Gateway
     email: cert-manager-maintainers@googlegroups.com

--- a/triage_party/letsencrypt-prod-issuer.yaml
+++ b/triage_party/letsencrypt-prod-issuer.yaml
@@ -1,0 +1,33 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt-prod
+  namespace: triageparty
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-prod-issuer-account-key
+    solvers:
+    - http01:
+        gatewayHTTPRoute:
+          serviceType: ClusterIP
+          parentRefs:
+            - name: triage-gateway
+              namespace: triageparty
+              kind: Gateway
+    email: cert-manager-maintainers@googlegroups.com

--- a/triage_party/triageparty_gateway.yaml
+++ b/triage_party/triageparty_gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   name: triage-gateway
   namespace: triageparty
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/issuer: letsencrypt-prod
     cert-manager.io/issue-temporary-certificate: "true"
 spec:
   gatewayClassName: gke-l7-global-external-managed


### PR DESCRIPTION
The HTTP01 solver was still configured to solve challenges using ingress instead of Gateway API.