### PR TITLE
Bump golang image for csi-lib

### DIFF
--- a/config/jobs/cert-manager/csi-lib/cert-manager-csi-lib-presubmits.yaml
+++ b/config/jobs/cert-manager/csi-lib/cert-manager-csi-lib-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     labels:
     spec:
       containers:
-      - image: golang:1.20
+      - image: golang:1.23
         args:
         - ./hack/verify-all.sh
         resources:


### PR DESCRIPTION
to Go 1.23, ref. https://github.com/cert-manager/csi-lib/pull/67.

/cc @inteon 