### PR TITLE
Update tested k8s versions to roughly match latest supported releases

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -70,108 +70,6 @@ presubmits:
     - master
     always_run: true
     optional: false
-  - name: pull-cert-manager-master-e2e-v1-25
-    max_concurrency: 4
-    decorate: true
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.25 cluster
-      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-      testgrid-create-job-group: "true"
-      testgrid-dashboards: cert-manager-presubmits-master
-    labels:
-      preset-cloudflare-credentials: "true"
-      preset-dind-enabled: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-go-cache: "true"
-      preset-local-cache: "true"
-      preset-retry-flakey-jobs: "true"
-    spec:
-      containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-        args:
-        - runner
-        - make
-        - -j7
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.25
-        resources:
-          requests:
-            cpu: 7000m
-            memory: 6Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
-      dnsPolicy: None
-      dnsConfig:
-        nameservers:
-        - 8.8.8.8
-        - 8.8.4.4
-    branches:
-    - master
-    always_run: false
-    optional: true
-  - name: pull-cert-manager-master-e2e-v1-26
-    max_concurrency: 4
-    decorate: true
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.26 cluster
-      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-      testgrid-create-job-group: "true"
-      testgrid-dashboards: cert-manager-presubmits-master
-    labels:
-      preset-cloudflare-credentials: "true"
-      preset-dind-enabled: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-go-cache: "true"
-      preset-local-cache: "true"
-      preset-retry-flakey-jobs: "true"
-    spec:
-      containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-        args:
-        - runner
-        - make
-        - -j7
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.26
-        resources:
-          requests:
-            cpu: 7000m
-            memory: 6Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
-      dnsPolicy: None
-      dnsConfig:
-        nameservers:
-        - 8.8.8.8
-        - 8.8.4.4
-    branches:
-    - master
-    always_run: false
-    optional: true
   - name: pull-cert-manager-master-e2e-v1-27
     max_concurrency: 4
     decorate: true
@@ -374,9 +272,60 @@ presubmits:
         - 8.8.4.4
     branches:
     - master
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-master-e2e-v1-31
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.31 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-job-group: "true"
+      testgrid-dashboards: cert-manager-presubmits-master
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.31
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - master
     always_run: true
     optional: false
-  - name: pull-cert-manager-master-e2e-v1-30-upgrade
+  - name: pull-cert-manager-master-e2e-v1-31-upgrade
     max_concurrency: 4
     decorate: true
     annotations:
@@ -394,7 +343,7 @@ presubmits:
         args:
         - runner
         - make
-        - K8S_VERSION=1.30
+        - K8S_VERSION=1.31
         - vendor-go
         - test-upgrade
         resources:
@@ -449,7 +398,7 @@ presubmits:
     always_run: false
     optional: true
     run_if_changed: go.mod
-  - name: pull-cert-manager-master-e2e-v1-30-issuers-venafi-tpp
+  - name: pull-cert-manager-master-e2e-v1-31-issuers-venafi-tpp
     max_concurrency: 4
     decorate: true
     annotations:
@@ -473,7 +422,7 @@ presubmits:
         - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.30
+        - K8S_VERSION=1.31
         resources:
           requests:
             cpu: 7000m
@@ -499,7 +448,7 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-30-issuers-venafi-cloud
+  - name: pull-cert-manager-master-e2e-v1-31-issuers-venafi-cloud
     max_concurrency: 4
     decorate: true
     annotations:
@@ -523,7 +472,7 @@ presubmits:
         - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.30
+        - K8S_VERSION=1.31
         resources:
           requests:
             cpu: 7000m
@@ -549,7 +498,7 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-30-feature-gates-disabled
+  - name: pull-cert-manager-master-e2e-v1-31-feature-gates-disabled
     max_concurrency: 4
     decorate: true
     annotations:
@@ -574,7 +523,7 @@ presubmits:
         - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.30
+        - K8S_VERSION=1.31
         resources:
           requests:
             cpu: 7000m
@@ -600,7 +549,7 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-30-bestpractice-install
+  - name: pull-cert-manager-master-e2e-v1-31-bestpractice-install
     max_concurrency: 4
     decorate: true
     annotations:
@@ -627,7 +576,7 @@ presubmits:
         - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.30
+        - K8S_VERSION=1.31
         resources:
           requests:
             cpu: 7000m
@@ -688,110 +637,6 @@ periodics:
     repo: cert-manager
     base_ref: master
   cron: 00 00-23/02 * * *
-- name: ci-cert-manager-master-e2e-v1-25
-  max_concurrency: 4
-  decorate: true
-  annotations:
-    description: Runs the end-to-end test suite against a Kubernetes v1.25 cluster
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-master
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-dind-enabled: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-go-cache: "true"
-    preset-local-cache: "true"
-    preset-retry-flakey-jobs: "true"
-  spec:
-    containers:
-    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-      args:
-      - runner
-      - make
-      - -j7
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.25
-      resources:
-        requests:
-          cpu: 7000m
-          memory: 6Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsPolicy: None
-    dnsConfig:
-      nameservers:
-      - 8.8.8.8
-      - 8.8.4.4
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  cron: 03 01-23/02 * * *
-- name: ci-cert-manager-master-e2e-v1-26
-  max_concurrency: 4
-  decorate: true
-  annotations:
-    description: Runs the end-to-end test suite against a Kubernetes v1.26 cluster
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-master
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-dind-enabled: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-go-cache: "true"
-    preset-local-cache: "true"
-    preset-retry-flakey-jobs: "true"
-  spec:
-    containers:
-    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-      args:
-      - runner
-      - make
-      - -j7
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.26
-      resources:
-        requests:
-          cpu: 7000m
-          memory: 6Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsPolicy: None
-    dnsConfig:
-      nameservers:
-      - 8.8.8.8
-      - 8.8.4.4
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  cron: 06 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-27
   max_concurrency: 4
   decorate: true
@@ -843,7 +688,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 09 01-23/02 * * *
+  cron: 04 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-28
   max_concurrency: 4
   decorate: true
@@ -895,7 +740,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 12 00-23/02 * * *
+  cron: 08 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-29
   max_concurrency: 4
   decorate: true
@@ -947,7 +792,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 15 01-23/02 * * *
+  cron: 12 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-30
   max_concurrency: 4
   decorate: true
@@ -999,23 +844,23 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 18 00-23/02 * * *
-- name: ci-cert-manager-master-e2e-v1-30-issuers-venafi
+  cron: 16 00-23/02 * * *
+- name: ci-cert-manager-master-e2e-v1-31
   max_concurrency: 4
   decorate: true
   annotations:
-    description: Runs Venafi (VaaS and TPP) e2e tests
+    description: Runs the end-to-end test suite against a Kubernetes v1.31 cluster
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-create-job-group: "true"
     testgrid-dashboards: cert-manager-periodics-master
   labels:
+    preset-cloudflare-credentials: "true"
     preset-dind-enabled: "true"
-    preset-ginkgo-focus-venafi: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
     preset-retry-flakey-jobs: "true"
-    preset-venafi-cloud-credentials: "true"
-    preset-venafi-tpp-credentials: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1025,7 +870,7 @@ periodics:
       - -j7
       - vendor-go
       - e2e-ci
-      - K8S_VERSION=1.30
+      - K8S_VERSION=1.31
       resources:
         requests:
           cpu: 7000m
@@ -1051,8 +896,60 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 21 00-23/12 * * *
-- name: ci-cert-manager-master-e2e-v1-30-upgrade
+  cron: 20 01-23/02 * * *
+- name: ci-cert-manager-master-e2e-v1-31-issuers-venafi
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs Venafi (VaaS and TPP) e2e tests
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-master
+  labels:
+    preset-dind-enabled: "true"
+    preset-ginkgo-focus-venafi: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-venafi-cloud-credentials: "true"
+    preset-venafi-tpp-credentials: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.31
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  cron: 24 00-23/12 * * *
+- name: ci-cert-manager-master-e2e-v1-31-upgrade
   max_concurrency: 4
   decorate: true
   annotations:
@@ -1070,7 +967,7 @@ periodics:
       args:
       - runner
       - make
-      - K8S_VERSION=1.30
+      - K8S_VERSION=1.31
       - vendor-go
       - test-upgrade
       resources:
@@ -1091,8 +988,8 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 24 00-23/08 * * *
-- name: ci-cert-manager-master-e2e-v1-30-bestpractice-install
+  cron: 28 00-23/08 * * *
+- name: ci-cert-manager-master-e2e-v1-31-bestpractice-install
   max_concurrency: 4
   decorate: true
   annotations:
@@ -1119,7 +1016,7 @@ periodics:
       - -j7
       - vendor-go
       - e2e-ci
-      - K8S_VERSION=1.30
+      - K8S_VERSION=1.31
       resources:
         requests:
           cpu: 7000m
@@ -1145,111 +1042,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 27 00-23/24 * * *
-- name: ci-cert-manager-master-e2e-v1-25-feature-gates-disabled
-  max_concurrency: 4
-  decorate: true
-  annotations:
-    description: Runs the E2E tests with all feature gates disabled
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-master
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-dind-enabled: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-go-cache: "true"
-    preset-local-cache: "true"
-    preset-retry-flakey-jobs: "true"
-  spec:
-    containers:
-    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-      args:
-      - runner
-      - make
-      - -j7
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.25
-      resources:
-        requests:
-          cpu: 7000m
-          memory: 6Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsPolicy: None
-    dnsConfig:
-      nameservers:
-      - 8.8.8.8
-      - 8.8.4.4
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  cron: 30 07-23/24 * * *
-- name: ci-cert-manager-master-e2e-v1-26-feature-gates-disabled
-  max_concurrency: 4
-  decorate: true
-  annotations:
-    description: Runs the E2E tests with all feature gates disabled
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-master
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-dind-enabled: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-go-cache: "true"
-    preset-local-cache: "true"
-    preset-retry-flakey-jobs: "true"
-  spec:
-    containers:
-    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-      args:
-      - runner
-      - make
-      - -j7
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.26
-      resources:
-        requests:
-          cpu: 7000m
-          memory: 6Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsPolicy: None
-    dnsConfig:
-      nameservers:
-      - 8.8.8.8
-      - 8.8.4.4
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  cron: 33 14-23/24 * * *
+  cron: 32 00-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-27-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1301,7 +1094,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 36 21-23/24 * * *
+  cron: 36 07-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-28-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1353,7 +1146,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 39 04-23/24 * * *
+  cron: 40 14-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-29-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1405,7 +1198,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 42 11-23/24 * * *
+  cron: 44 21-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-30-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1457,7 +1250,59 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 45 18-23/24 * * *
+  cron: 48 04-23/24 * * *
+- name: ci-cert-manager-master-e2e-v1-31-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-master
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.31
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  cron: 52 11-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-controller
   max_concurrency: 2
   decorate: true
@@ -1496,7 +1341,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 48 01-23/24 * * *
+  cron: 56 18-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-acmesolver
   max_concurrency: 2
   decorate: true
@@ -1535,7 +1380,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 51 08-23/24 * * *
+  cron: 00 01-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-startupapicheck
   max_concurrency: 2
   decorate: true
@@ -1574,7 +1419,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 54 15-23/24 * * *
+  cron: 04 08-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-cainjector
   max_concurrency: 2
   decorate: true
@@ -1613,7 +1458,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 57 22-23/24 * * *
+  cron: 08 15-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-webhook
   max_concurrency: 2
   decorate: true
@@ -1652,4 +1497,4 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 00 05-23/24 * * *
+  cron: 12 22-23/24 * * *

--- a/config/prowgen/prowspecs/specs.go
+++ b/config/prowgen/prowspecs/specs.go
@@ -49,7 +49,10 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 		},
 
 		primaryKubernetesVersion: "1.27",
-		otherKubernetesVersions:  []string{"1.22", "1.23", "1.24", "1.25", "1.26", "1.28", "1.29"},
+		// NB: It would be nice to test 1.30 and 1.31 (and newer) here but newer versions of Kind don't
+		// build images to support testing older k8s versions. E.g. kind v0.24.0 doesn't have images for
+		// Kubernetes 1.24 and below
+		otherKubernetesVersions: []string{"1.22", "1.23", "1.24", "1.25", "1.26", "1.28", "1.29"},
 
 		e2eCPURequest:    "7000m",
 		e2eMemoryRequest: "6Gi",
@@ -104,7 +107,9 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 		},
 
 		primaryKubernetesVersion: "1.30",
-		otherKubernetesVersions:  []string{"1.25", "1.26", "1.27", "1.28", "1.29"},
+
+		// TODO: test k8s 1.31 here when possible; requires support in the release-1.15 branch on cert-manager
+		otherKubernetesVersions: []string{"1.25", "1.26", "1.27", "1.28", "1.29"},
 
 		e2eCPURequest:    "7000m",
 		e2eMemoryRequest: "6Gi",
@@ -123,8 +128,8 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 			Repo: "cert-manager",
 		},
 
-		primaryKubernetesVersion: "1.30",
-		otherKubernetesVersions:  []string{"1.25", "1.26", "1.27", "1.28", "1.29"},
+		primaryKubernetesVersion: "1.31",
+		otherKubernetesVersions:  []string{"1.27", "1.28", "1.29", "1.30"},
 
 		e2eCPURequest:    "7000m",
 		e2eMemoryRequest: "6Gi",


### PR DESCRIPTION
See https://github.com/cert-manager/website/pull/1563 for the latest changes.

This doesn't add testing for k8s 1.31 against cert-manager 1.15, 1.14 or 1.12

- For 1.15, futher changes are needed in upstream cert-manager to enable testing 1.31
- For 1.14, it'll be EOL in a couple of weeks so we'll probably just ignore 1.31 there.
- For 1.12, see the comment I wrote; I don't want to tackle testing both 1.22 and 1.31 in this PR (maybe we won't ever tackle it)