### PR TITLE
Setup tests for release-1.16

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -111,8 +111,8 @@ branch-protection:
                 contexts:
                 - pull-cert-manager-master-make-verify
                 - pull-cert-manager-master-make-test
-                - pull-cert-manager-master-e2e-v1-30
-                - pull-cert-manager-master-e2e-v1-30-upgrade
+                - pull-cert-manager-master-e2e-v1-31
+                - pull-cert-manager-master-e2e-v1-31-upgrade
         website:
           required_status_checks:
             contexts:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -45,11 +45,11 @@ branch-protection:
       # Causes the "Include Administrators" checkbox to be ticked in the GitHub branch protection UI.
       # See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#do-not-allow-bypassing-the-above-settings
       enforce_admins: true
-      # Disallow force pushes to the protected branch. 
+      # Disallow force pushes to the protected branch.
       allow_force_pushes: false
       # Disallow deletion of the protected branch.
       allow_deletions: false
-      
+
       # In the GH UI, the following 'required_pull_request_reviews' configuration
       # results in checking the 'Require a pull request before merging' checkbox,
       # without checking any of it's child checkboxes. We must set the
@@ -99,6 +99,13 @@ branch-protection:
                 - pull-cert-manager-release-1.15-make-test
                 - pull-cert-manager-release-1.15-e2e-v1-30
                 - pull-cert-manager-release-1.15-e2e-v1-30-upgrade
+            release-1.16:
+              required_status_checks:
+                contexts:
+                - pull-cert-manager-release-1.16-make-verify
+                - pull-cert-manager-release-1.16-make-test
+                - pull-cert-manager-release-1.16-e2e-v1-31
+                - pull-cert-manager-release-1.16-e2e-v1-31-upgrade
             master:
               required_status_checks:
                 contexts:

--- a/config/jobs/cert-manager/cert-manager/release-1.16/cert-manager-release-1.16.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.16/cert-manager-release-1.16.yaml
@@ -1,0 +1,1461 @@
+# THIS FILE HAS BEEN AUTOMATICALLY GENERATED
+# Don't manually edit it; instead edit the "prowgen" tool which generated it
+# Generated with: prowgen --branch=* -o cert-manager
+
+presubmits:
+  cert-manager/cert-manager:
+  - name: pull-cert-manager-release-1.16-make-verify
+    max_concurrency: 8
+    decorate: true
+    annotations:
+      description: Runs linting and verification targets
+    labels:
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - -j2
+        - vendor-go
+        - ci-presubmit
+        resources:
+          requests:
+            cpu: 2000m
+            memory: 4Gi
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - release-1.16
+    always_run: true
+    optional: false
+  - name: pull-cert-manager-release-1.16-make-test
+    max_concurrency: 8
+    decorate: true
+    annotations:
+      description: Runs unit and integration tests
+    labels:
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - -j2
+        - vendor-go
+        - test-ci
+        resources:
+          requests:
+            cpu: 2000m
+            memory: 4Gi
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - release-1.16
+    always_run: true
+    optional: false
+  - name: pull-cert-manager-release-1.16-e2e-v1-27
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.27 cluster
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.27
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - release-1.16
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.16-e2e-v1-28
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.28 cluster
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.28
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - release-1.16
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.16-e2e-v1-29
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.29 cluster
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.29
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - release-1.16
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.16-e2e-v1-30
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.30 cluster
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.30
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - release-1.16
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.16-e2e-v1-31
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.31 cluster
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.31
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - release-1.16
+    always_run: true
+    optional: false
+  - name: pull-cert-manager-release-1.16-e2e-v1-31-upgrade
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs cert-manager upgrade from latest published release
+    labels:
+      preset-dind-enabled: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - K8S_VERSION=1.31
+        - vendor-go
+        - test-upgrade
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - release-1.16
+    always_run: true
+    optional: false
+  - name: pull-cert-manager-release-1.16-license
+    max_concurrency: 8
+    decorate: true
+    annotations:
+      description: Verifies LICENSES are up to date; only needs to be run if go.mod
+        has changed
+    labels:
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - vendor-go
+        - verify-licenses
+        resources:
+          requests:
+            cpu: "1"
+            memory: 1Gi
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - release-1.16
+    always_run: false
+    optional: true
+    run_if_changed: go.mod
+  - name: pull-cert-manager-release-1.16-e2e-v1-31-issuers-venafi-tpp
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the E2E tests with 'Venafi TPP' in name
+    labels:
+      preset-dind-enabled: "true"
+      preset-ginkgo-focus-venafi-tpp: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-venafi-tpp-credentials: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.31
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - release-1.16
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.16-e2e-v1-31-issuers-venafi-cloud
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the E2E tests with 'Venafi Cloud' in name
+    labels:
+      preset-dind-enabled: "true"
+      preset-ginkgo-focus-venafi-cloud: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+      preset-venafi-cloud-credentials: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.31
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - release-1.16
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.16-e2e-v1-31-feature-gates-disabled
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the E2E tests with all feature gates disabled
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.31
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - release-1.16
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-release-1.16-e2e-v1-31-bestpractice-install
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the E2E tests with cert-manager installed in accordance with
+        https://cert-manager.io/docs/installation/best-practice/
+    labels:
+      preset-bestpractice-install: "true"
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-disable-all-alpha-beta-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.31
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - release-1.16
+    always_run: false
+    optional: true
+periodics:
+- name: ci-cert-manager-release-1.16-make-test
+  max_concurrency: 8
+  decorate: true
+  annotations:
+    description: Runs unit and integration tests
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.16
+  labels:
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j2
+      - vendor-go
+      - test-ci
+      resources:
+        requests:
+          cpu: 2000m
+          memory: 4Gi
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.16
+  cron: 00 00-23/02 * * *
+- name: ci-cert-manager-release-1.16-e2e-v1-27
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.27 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.16
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.27
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.16
+  cron: 04 01-23/02 * * *
+- name: ci-cert-manager-release-1.16-e2e-v1-28
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.28 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.16
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.28
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.16
+  cron: 08 00-23/02 * * *
+- name: ci-cert-manager-release-1.16-e2e-v1-29
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.29 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.16
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.29
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.16
+  cron: 12 01-23/02 * * *
+- name: ci-cert-manager-release-1.16-e2e-v1-30
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.30 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.16
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.30
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.16
+  cron: 16 00-23/02 * * *
+- name: ci-cert-manager-release-1.16-e2e-v1-31
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.31 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.16
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.31
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.16
+  cron: 20 01-23/02 * * *
+- name: ci-cert-manager-release-1.16-e2e-v1-31-issuers-venafi
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs Venafi (VaaS and TPP) e2e tests
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.16
+  labels:
+    preset-dind-enabled: "true"
+    preset-ginkgo-focus-venafi: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+    preset-venafi-cloud-credentials: "true"
+    preset-venafi-tpp-credentials: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.31
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.16
+  cron: 24 04-23/12 * * *
+- name: ci-cert-manager-release-1.16-e2e-v1-31-upgrade
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs cert-manager upgrade from latest published release
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.16
+  labels:
+    preset-dind-enabled: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - K8S_VERSION=1.31
+      - vendor-go
+      - test-upgrade
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.16
+  cron: 28 04-23/08 * * *
+- name: ci-cert-manager-release-1.16-e2e-v1-31-bestpractice-install
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with cert-manager installed in accordance with
+      https://cert-manager.io/docs/installation/best-practice/
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.16
+  labels:
+    preset-bestpractice-install: "true"
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.31
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.16
+  cron: 32 04-23/24 * * *
+- name: ci-cert-manager-release-1.16-e2e-v1-27-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.16
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.27
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.16
+  cron: 36 11-23/24 * * *
+- name: ci-cert-manager-release-1.16-e2e-v1-28-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.16
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.28
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.16
+  cron: 40 18-23/24 * * *
+- name: ci-cert-manager-release-1.16-e2e-v1-29-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.16
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.29
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.16
+  cron: 44 01-23/24 * * *
+- name: ci-cert-manager-release-1.16-e2e-v1-30-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.16
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.30
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.16
+  cron: 48 08-23/24 * * *
+- name: ci-cert-manager-release-1.16-e2e-v1-31-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.16
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.31
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.16
+  cron: 52 15-23/24 * * *
+- name: ci-cert-manager-release-1.16-trivy-test-controller
+  max_concurrency: 2
+  decorate: true
+  annotations:
+    description: Runs a Trivy scan against the controller container
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-alert-stale-results-hours: "36"
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.16
+    testgrid-num-failures-to-alert: "1"
+  labels:
+    preset-dind-enabled: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j1
+      - vendor-go
+      - trivy-scan-controller
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+      securityContext:
+        privileged: true
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.16
+  cron: 56 22-23/24 * * *
+- name: ci-cert-manager-release-1.16-trivy-test-acmesolver
+  max_concurrency: 2
+  decorate: true
+  annotations:
+    description: Runs a Trivy scan against the acmesolver container
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-alert-stale-results-hours: "36"
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.16
+    testgrid-num-failures-to-alert: "1"
+  labels:
+    preset-dind-enabled: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j1
+      - vendor-go
+      - trivy-scan-acmesolver
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+      securityContext:
+        privileged: true
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.16
+  cron: 00 05-23/24 * * *
+- name: ci-cert-manager-release-1.16-trivy-test-startupapicheck
+  max_concurrency: 2
+  decorate: true
+  annotations:
+    description: Runs a Trivy scan against the startupapicheck container
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-alert-stale-results-hours: "36"
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.16
+    testgrid-num-failures-to-alert: "1"
+  labels:
+    preset-dind-enabled: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j1
+      - vendor-go
+      - trivy-scan-startupapicheck
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+      securityContext:
+        privileged: true
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.16
+  cron: 04 12-23/24 * * *
+- name: ci-cert-manager-release-1.16-trivy-test-cainjector
+  max_concurrency: 2
+  decorate: true
+  annotations:
+    description: Runs a Trivy scan against the cainjector container
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-alert-stale-results-hours: "36"
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.16
+    testgrid-num-failures-to-alert: "1"
+  labels:
+    preset-dind-enabled: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j1
+      - vendor-go
+      - trivy-scan-cainjector
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+      securityContext:
+        privileged: true
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.16
+  cron: 08 19-23/24 * * *
+- name: ci-cert-manager-release-1.16-trivy-test-webhook
+  max_concurrency: 2
+  decorate: true
+  annotations:
+    description: Runs a Trivy scan against the webhook container
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-alert-stale-results-hours: "36"
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.16
+    testgrid-num-failures-to-alert: "1"
+  labels:
+    preset-dind-enabled: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j1
+      - vendor-go
+      - trivy-scan-webhook
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+      securityContext:
+        privileged: true
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.16
+  cron: 12 02-23/24 * * *

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -39,7 +39,8 @@ repo_milestone:
 
 milestone_applier:
   cert-manager/cert-manager:
-    master: v1.16
+    master: v1.17
+    release-1.16: v1.16
     release-1.15: v1.15
     release-1.14: v1.14
     release-1.12: v1.12

--- a/config/prowgen/prowspecs/specs.go
+++ b/config/prowgen/prowspecs/specs.go
@@ -114,6 +114,27 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 		e2eCPURequest:    "7000m",
 		e2eMemoryRequest: "6Gi",
 	},
+	"release-1.16": {
+		prowContext: &pkg.ProwContext{
+			Branch: "release-1.16",
+
+			// Use latest image.
+			Image: pkg.CommonTestImage,
+
+			// NB: we don't use a presubmit dashboard outside of "master", currently
+			PresubmitDashboard: false,
+			PeriodicDashboard:  true,
+
+			Org:  "cert-manager",
+			Repo: "cert-manager",
+		},
+
+		primaryKubernetesVersion: "1.31",
+		otherKubernetesVersions:  []string{"1.27", "1.28", "1.29", "1.30"},
+
+		e2eCPURequest:    "7000m",
+		e2eMemoryRequest: "6Gi",
+	},
 	"master": {
 		prowContext: &pkg.ProwContext{
 			Branch: "master",

--- a/config/prowgen/prowspecs/specs.go
+++ b/config/prowgen/prowspecs/specs.go
@@ -108,7 +108,6 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 
 		primaryKubernetesVersion: "1.30",
 
-		// TODO: test k8s 1.31 here when possible; requires support in the release-1.15 branch on cert-manager
 		otherKubernetesVersions: []string{"1.25", "1.26", "1.27", "1.28", "1.29", "1.31"},
 
 		e2eCPURequest:    "7000m",

--- a/config/testgrid/dashboards.yaml
+++ b/config/testgrid/dashboards.yaml
@@ -6,6 +6,7 @@ dashboard_groups:
   - cert-manager-periodics-release-1.12
   - cert-manager-periodics-release-1.14
   - cert-manager-periodics-release-1.15
+  - cert-manager-periodics-release-1.16
   - cert-manager-presubmits-master
   - cert-manager-testing-janitors
 
@@ -15,5 +16,6 @@ dashboards:
 - name: cert-manager-periodics-release-1.12
 - name: cert-manager-periodics-release-1.14
 - name: cert-manager-periodics-release-1.15
+- name: cert-manager-periodics-release-1.16
 - name: cert-manager-presubmits-master
 - name: cert-manager-testing-janitors


### PR DESCRIPTION
As described in the section "Proceed to the post-release "testing and release" steps:" in https://cert-manager.io/docs/contributing/release-process/#minor-releases

Also a couple of drive by fixes.