### PR TITLE
Mitigate the impact of Trivy DB download rate limiting on GHCR by using a Trivy DB mirror

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -1317,6 +1317,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1356,6 +1357,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1395,6 +1397,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1434,6 +1437,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1473,6 +1477,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm

--- a/config/jobs/cert-manager/cert-manager/release-1.12/cert-manager-release-1.12.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.12/cert-manager-release-1.12.yaml
@@ -1738,6 +1738,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1777,6 +1778,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1816,6 +1818,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1855,6 +1858,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1894,6 +1898,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm

--- a/config/jobs/cert-manager/cert-manager/release-1.14/cert-manager-release-1.14.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.14/cert-manager-release-1.14.yaml
@@ -1434,6 +1434,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1473,6 +1474,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1512,6 +1514,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1551,6 +1554,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1590,6 +1594,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1629,6 +1634,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm

--- a/config/jobs/cert-manager/cert-manager/release-1.15/cert-manager-release-1.15.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.15/cert-manager-release-1.15.yaml
@@ -1582,6 +1582,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1621,6 +1622,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1660,6 +1662,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1699,6 +1702,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1738,6 +1742,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm

--- a/config/jobs/cert-manager/cert-manager/release-1.16/cert-manager-release-1.16.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.16/cert-manager-release-1.16.yaml
@@ -1278,6 +1278,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1317,6 +1318,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1356,6 +1358,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1395,6 +1398,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
@@ -1434,6 +1438,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-go-cache: "true"
     preset-local-cache: "true"
+    preset-trivy: "true"
   spec:
     containers:
     - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm

--- a/config/jobs/cert-manager/config.yaml
+++ b/config/jobs/cert-manager/config.yaml
@@ -129,6 +129,23 @@ presets:
   - name: GINKGO_FOCUS
     value: "Venafi Cloud"
 
+# This preset adds common configuration for all trivy jobs
+#
+# 1. Mitigate the impact of Trivy DB download rate limiting on GHCR. E.g.
+#    >  2024-09-30T19:10:14Z FATAL Fatal error init error: DB error: failed to
+#    >  download vulnerability DB: database download error: OCI repository error: 1
+#    >  error occurred:
+#    >  	* GET https://ghcr.io/v2/aquasecurity/trivy-db/manifests/2: TOOMANYREQUESTS: retry-after: 203.192µs, allowed: 44000/minute
+#    By using an alternative registry mirror for the database. See:
+#    - https://github.com/aquasecurity/trivy-action/issues/389
+#    - https://aquasecurity.github.io/trivy/v0.55/docs/configuration/db/#db-repository
+#    - https://aquasecurity.github.io/trivy/v0.55/docs/configuration/#environment-variables
+- labels:
+    preset-trivy: "true"
+  env:
+  - name: TRIVY_DB_REPOSITORY
+    value: "public.ecr.aws/aquasecurity/trivy-db:2"
+
 # This preset is used to enable the logic in the make-dind runner that manages
 # a local cache and shares that cache with other jobs after successful completion.
 # The runner script populates the LOCAL_CACHE_DIR location with a copy of the latest

--- a/config/prowgen/pkg/configurers.go
+++ b/config/prowgen/pkg/configurers.go
@@ -52,6 +52,10 @@ func jobTemplate(name string, description string, configurers ...JobConfigurer) 
 	return job
 }
 
+func addTrivyLabel(job *Job) {
+	job.Labels["preset-trivy"] = "true"
+}
+
 func addLocalCacheLabel(job *Job) {
 	job.Labels["preset-local-cache"] = "true"
 }

--- a/config/prowgen/pkg/generators.go
+++ b/config/prowgen/pkg/generators.go
@@ -422,6 +422,7 @@ func TrivyTest(ctx *ProwContext, containerName string) *Job {
 		addLocalCacheLabel,
 		addGoCacheLabel,
 		addDindLabel,
+		addTrivyLabel,
 		addMaxConcurrency(2),
 		// Need to ensure that trivy tests send a failure email as soon as they fail since
 		// they tend to be run relatively infrequently and a failure is important to address


### PR DESCRIPTION
Mitigate the impact of Trivy DB download rate limiting on GHCR

E.g.
>  2024-09-30T19:10:14Z FATAL Fatal error init error: DB error: failed to
>  download vulnerability DB: database download error: OCI repository error: 1
>  error occurred:
>  	* GET https://ghcr.io/v2/aquasecurity/trivy-db/manifests/2: TOOMANYREQUESTS: retry-after: 203.192µs, allowed: 44000/minute
> -- https://prow.infra.cert-manager.io/view/gs/cert-manager-prow-artifacts/logs/ci-cert-manager-release-1.16-trivy-test-cainjector/1840831081448738816

By using an alternative registry mirror for the database. 

It is more convenient to fix this here in the testing repo than to update the Make rule in makefile modules,
then backport it to all the affected release- branches.
Hopefully, trivy find some general work around in a future version. Maybe they will persuade GHCR to increase their rate limits.
Or they'll switch to a new default registry or find some alternative non-oci mechanism for distributing the DB.

Aim is to  get the test grid green before the cert-manager 1.16 release:
 * https://testgrid.k8s.io/cert-manager-periodics-release-1.16

<img width="960" alt="image" src="https://github.com/user-attachments/assets/142c842a-20b2-4056-9651-3fb6e06b7935">


See:
- https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1727433814116729
- https://github.com/aquasecurity/trivy-action/issues/389
- https://aquasecurity.github.io/trivy/v0.55/docs/configuration/db/#db-repository
- https://aquasecurity.github.io/trivy/v0.55/docs/configuration/#environment-variables
