### PR TITLE
Omit the trivy DB schema version for backwards compatibility with trivy < 0.50.0

### DIFF
--- a/config/jobs/cert-manager/config.yaml
+++ b/config/jobs/cert-manager/config.yaml
@@ -140,11 +140,13 @@ presets:
 #    - https://github.com/aquasecurity/trivy-action/issues/389
 #    - https://aquasecurity.github.io/trivy/v0.55/docs/configuration/db/#db-repository
 #    - https://aquasecurity.github.io/trivy/v0.55/docs/configuration/#environment-variables
+#    Omit the OCI tag (schema version), for backwards compatibility with trivy < 0.50.0:
+#    - https://github.com/aquasecurity/trivy/pull/6219
 - labels:
     preset-trivy: "true"
   env:
   - name: TRIVY_DB_REPOSITORY
-    value: "public.ecr.aws/aquasecurity/trivy-db:2"
+    value: "public.ecr.aws/aquasecurity/trivy-db"
 
 # This preset is used to enable the logic in the make-dind runner that manages
 # a local cache and shares that cache with other jobs after successful completion.


### PR DESCRIPTION
In https://github.com/cert-manager/testing/pull/1062#issuecomment-2386536745 @inteon noticed that the trivy tests were now failing on cert-manager 1.12 and 1.14 branches.
Those releases use an older version of trivy < 0.50.0 which unconditionally appends the schema version (tag) to the supplied DB registry.
Newer versions of trivy >= 0.50.0, only append the schema version if it has not been supplied, and log a backwards compatibility message in that case:
 * https://github.com/aquasecurity/trivy/pull/6219 (v0.50.0)
 * https://github.com/aquasecurity/trivy/pull/6410 (v0.51.0)

So to support both old and new versions, I've removed the schema version from the DB registry variable.

## Testing

I ran trivy on all the release branches and observed it download the DB successfully:

```bash
for release in 1.12 1.14 1.15 1.16; do 
  echo "RELEASE: $release"; 
  git checkout "origin/release-$release"; 
  > ~/.cache/trivy/db/metadata.json; 
  make trivy-scan-acmesolver TRIVY_DB_REPOSITORY=public.ecr.aws/aquasecurity/trivy-db > $release.stdout; 
done
```

```console
RELEASE: 1.12
Previous HEAD position was e381fb0c2 Merge pull request #7318 from cert-manager-bot/cherry-pick-7315-to-release-1.16
HEAD is now at 231a4bdfc Merge pull request #7224 from wallrj/update-cmd/ctl/v1.12.13
2024-10-02T06:37:52.482+0100    INFO    Need to update DB
2024-10-02T06:37:52.482+0100    INFO    DB Repository: public.ecr.aws/aquasecurity/trivy-db
2024-10-02T06:37:52.482+0100    INFO    Downloading DB...
53.93 MiB / 53.93 MiB [------------------------------------------------------------------------------------] 100.00% 2.19 MiB p/s 25s
...
RELEASE: 1.14
Previous HEAD position was 231a4bdfc Merge pull request #7224 from wallrj/update-cmd/ctl/v1.12.13
HEAD is now at 99d4b3189 Merge pull request #7225 from ThatsMrTalbot/chore/release-1.14-update-base-images
2024-10-02T06:38:26.759+0100    INFO    Need to update DB
2024-10-02T06:38:26.759+0100    INFO    DB Repository: public.ecr.aws/aquasecurity/trivy-db
2024-10-02T06:38:26.759+0100    INFO    Downloading DB...
53.93 MiB / 53.93 MiB [------------------------------------------------------------------------------------] 100.00% 1.92 MiB p/s 28s
...
RELEASE: 1.15
Previous HEAD position was 99d4b3189 Merge pull request #7225 from ThatsMrTalbot/chore/release-1.14-update-base-images
HEAD is now at 3155085d6 Merge pull request #7305 from SgtCoDFish/release-1.15-moretesting
2024-10-02T06:39:00.505+0100    INFO    Need to update DB
2024-10-02T06:39:00.505+0100    INFO    DB Repository: public.ecr.aws/aquasecurity/trivy-db
2024-10-02T06:39:00.505+0100    INFO    Downloading DB...
53.93 MiB / 53.93 MiB [------------------------------------------------------------------------------------] 100.00% 2.25 MiB p/s 24s
...
RELEASE: 1.16
Previous HEAD position was 3155085d6 Merge pull request #7305 from SgtCoDFish/release-1.15-moretesting
HEAD is now at e381fb0c2 Merge pull request #7318 from cert-manager-bot/cherry-pick-7315-to-release-1.16
2024-10-02T06:39:30+01:00       INFO    Adding schema version to the DB repository for backward compatibility   repository="public.ecr.aws/aquasecurity/trivy-db:2"
2024-10-02T06:39:30+01:00       INFO    [db] Need to update DB
2024-10-02T06:39:30+01:00       INFO    [db] Downloading DB...  repository="public.ecr.aws/aquasecurity/trivy-db:2"
53.93 MiB / 53.93 MiB [------------------------------------------------------------------------------------] 100.00% 2.20 MiB p/s 25s
...
```
