### PR TITLE
Don't test master against k8s 1.27

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -70,57 +70,6 @@ presubmits:
     - master
     always_run: true
     optional: false
-  - name: pull-cert-manager-master-e2e-v1-27
-    max_concurrency: 4
-    decorate: true
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.27 cluster
-      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-      testgrid-create-job-group: "true"
-      testgrid-dashboards: cert-manager-presubmits-master
-    labels:
-      preset-cloudflare-credentials: "true"
-      preset-dind-enabled: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-go-cache: "true"
-      preset-local-cache: "true"
-      preset-retry-flakey-jobs: "true"
-    spec:
-      containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-        args:
-        - runner
-        - make
-        - -j7
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.27
-        resources:
-          requests:
-            cpu: 7000m
-            memory: 6Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
-      dnsPolicy: None
-      dnsConfig:
-        nameservers:
-        - 8.8.8.8
-        - 8.8.4.4
-    branches:
-    - master
-    always_run: false
-    optional: true
   - name: pull-cert-manager-master-e2e-v1-28
     max_concurrency: 4
     decorate: true
@@ -637,58 +586,6 @@ periodics:
     repo: cert-manager
     base_ref: master
   cron: 00 00-23/02 * * *
-- name: ci-cert-manager-master-e2e-v1-27
-  max_concurrency: 4
-  decorate: true
-  annotations:
-    description: Runs the end-to-end test suite against a Kubernetes v1.27 cluster
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-master
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-dind-enabled: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-go-cache: "true"
-    preset-local-cache: "true"
-    preset-retry-flakey-jobs: "true"
-  spec:
-    containers:
-    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-      args:
-      - runner
-      - make
-      - -j7
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.27
-      resources:
-        requests:
-          cpu: 7000m
-          memory: 6Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsPolicy: None
-    dnsConfig:
-      nameservers:
-      - 8.8.8.8
-      - 8.8.4.4
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  cron: 04 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-28
   max_concurrency: 4
   decorate: true
@@ -740,7 +637,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 08 00-23/02 * * *
+  cron: 04 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-29
   max_concurrency: 4
   decorate: true
@@ -792,7 +689,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 12 01-23/02 * * *
+  cron: 08 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-30
   max_concurrency: 4
   decorate: true
@@ -844,7 +741,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 16 00-23/02 * * *
+  cron: 12 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-31
   max_concurrency: 4
   decorate: true
@@ -896,7 +793,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 20 01-23/02 * * *
+  cron: 16 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-31-issuers-venafi
   max_concurrency: 4
   decorate: true
@@ -948,7 +845,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 24 00-23/12 * * *
+  cron: 20 00-23/12 * * *
 - name: ci-cert-manager-master-e2e-v1-31-upgrade
   max_concurrency: 4
   decorate: true
@@ -988,7 +885,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 28 00-23/08 * * *
+  cron: 24 00-23/08 * * *
 - name: ci-cert-manager-master-e2e-v1-31-bestpractice-install
   max_concurrency: 4
   decorate: true
@@ -1042,59 +939,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 32 00-23/24 * * *
-- name: ci-cert-manager-master-e2e-v1-27-feature-gates-disabled
-  max_concurrency: 4
-  decorate: true
-  annotations:
-    description: Runs the E2E tests with all feature gates disabled
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-master
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-dind-enabled: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-go-cache: "true"
-    preset-local-cache: "true"
-    preset-retry-flakey-jobs: "true"
-  spec:
-    containers:
-    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-      args:
-      - runner
-      - make
-      - -j7
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.27
-      resources:
-        requests:
-          cpu: 7000m
-          memory: 6Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsPolicy: None
-    dnsConfig:
-      nameservers:
-      - 8.8.8.8
-      - 8.8.4.4
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  cron: 36 07-23/24 * * *
+  cron: 28 00-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-28-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1146,7 +991,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 40 14-23/24 * * *
+  cron: 32 07-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-29-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1198,7 +1043,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 44 21-23/24 * * *
+  cron: 36 14-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-30-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1250,7 +1095,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 48 04-23/24 * * *
+  cron: 40 21-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-31-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1302,7 +1147,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 52 11-23/24 * * *
+  cron: 44 04-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-controller
   max_concurrency: 2
   decorate: true
@@ -1342,7 +1187,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 56 18-23/24 * * *
+  cron: 48 11-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-acmesolver
   max_concurrency: 2
   decorate: true
@@ -1382,7 +1227,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 00 01-23/24 * * *
+  cron: 52 18-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-startupapicheck
   max_concurrency: 2
   decorate: true
@@ -1422,7 +1267,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 04 08-23/24 * * *
+  cron: 56 01-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-cainjector
   max_concurrency: 2
   decorate: true
@@ -1462,7 +1307,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 08 15-23/24 * * *
+  cron: 00 08-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-webhook
   max_concurrency: 2
   decorate: true
@@ -1502,4 +1347,4 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 12 22-23/24 * * *
+  cron: 04 15-23/24 * * *

--- a/config/prowgen/prowspecs/specs.go
+++ b/config/prowgen/prowspecs/specs.go
@@ -121,7 +121,7 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 		},
 
 		primaryKubernetesVersion: "1.31",
-		otherKubernetesVersions:  []string{"1.27", "1.28", "1.29", "1.30"},
+		otherKubernetesVersions:  []string{"1.28", "1.29", "1.30"},
 
 		e2eCPURequest:    "7000m",
 		e2eMemoryRequest: "6Gi",


### PR DESCRIPTION
By the time we release cert-manager 1.17 in ~Feb 2025, all cloud providers will have dropped support for Kubernetes 1.27 except OpenShift.

I think we should drop 1.27 as a tested version but keep it as a supported version, as per the recently added documentation on our supported releases page: https://cert-manager.io/docs/releases/#supported-vs-tested-versions-of-kubernetes