### PR TITLE
istio-csr Test Cleanup / Addition

### DIFF
--- a/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-periodics.yaml
+++ b/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-periodics.yaml
@@ -1,0 +1,37 @@
+periodics:
+- name: istio-csr-latest-istio-periodic
+  decorate: true
+  annotations:
+    description: Runs istio-csr's e2e test on the latest version of Istio
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: istio-csr-periodics
+  labels:
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-dind-enabled: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - bash
+      - -c
+      - "ISTIO_VERSION=$(make -s print-latest-istio-version) runner make vendor-go test-e2e"
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add: ["SYS_ADMIN"]
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: istio-csr
+    base_ref: main
+  cron: 42 */12 * * * # run at 13:42 and 01:42 every day

--- a/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
+++ b/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-presubmits.yaml
@@ -137,102 +137,6 @@ presubmits:
         - 8.8.4.4
 
 
-  - name: pull-cert-manager-istio-csr-istio-v1-17
-    decorate: true
-    always_run: true
-    labels:
-      preset-go-cache: "true"
-      preset-local-cache: "true"
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-        args:
-        - runner
-        - make
-        - vendor-go
-        - test-e2e
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 6Gi
-        env:
-        - name: ISTIO_VERSION
-          value: "1.17.8"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsPolicy: None
-      dnsConfig:
-        nameservers:
-        - 8.8.8.8
-        - 8.8.4.4
-
-  - name: pull-cert-manager-istio-csr-istio-v1-18
-    decorate: true
-    always_run: true
-    labels:
-      preset-go-cache: "true"
-      preset-local-cache: "true"
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-        args:
-        - runner
-        - make
-        - vendor-go
-        - test-e2e
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 6Gi
-        env:
-        - name: ISTIO_VERSION
-          value: "1.18.7"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsPolicy: None
-      dnsConfig:
-        nameservers:
-        - 8.8.8.8
-        - 8.8.4.4
-
-  - name: pull-cert-manager-istio-csr-istio-v1-19
-    decorate: true
-    always_run: true
-    labels:
-      preset-go-cache: "true"
-      preset-local-cache: "true"
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-        args:
-        - runner
-        - make
-        - vendor-go
-        - test-e2e
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 6Gi
-        env:
-        - name: ISTIO_VERSION
-          value: "1.19.9"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsPolicy: None
-      dnsConfig:
-        nameservers:
-        - 8.8.8.8
-        - 8.8.4.4
-
   - name: pull-cert-manager-istio-csr-istio-v1-20
     decorate: true
     always_run: true
@@ -286,7 +190,7 @@ presubmits:
             memory: 6Gi
         env:
         - name: ISTIO_VERSION
-          value: "1.21.4"
+          value: "1.21.6"
         securityContext:
           privileged: true
           capabilities:
@@ -318,7 +222,71 @@ presubmits:
             memory: 6Gi
         env:
         - name: ISTIO_VERSION
-          value: "1.22.3"
+          value: "1.22.6"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+
+  - name: pull-cert-manager-istio-csr-istio-v1-23
+    decorate: true
+    always_run: true
+    labels:
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - vendor-go
+        - test-e2e
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 6Gi
+        env:
+        - name: ISTIO_VERSION
+          value: "1.23.2"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+
+  - name: pull-cert-manager-istio-csr-istio-v1-24
+    decorate: true
+    always_run: true
+    labels:
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - vendor-go
+        - test-e2e
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 6Gi
+        env:
+        - name: ISTIO_VERSION
+          value: "1.24.0-alpha.0"
         securityContext:
           privileged: true
           capabilities:
@@ -377,70 +345,6 @@ presubmits:
           requests:
             cpu: 3500m
             memory: 6Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsPolicy: None
-      dnsConfig:
-        nameservers:
-        - 8.8.8.8
-        - 8.8.4.4
-
-  - name: pull-cert-manager-istio-csr-istio-v1-23
-    decorate: true
-    always_run: true
-    labels:
-      preset-go-cache: "true"
-      preset-local-cache: "true"
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-        args:
-        - runner
-        - make
-        - vendor-go
-        - test-e2e
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 6Gi
-        env:
-        - name: ISTIO_VERSION
-          value: "1.23.0"
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN"]
-      dnsPolicy: None
-      dnsConfig:
-        nameservers:
-        - 8.8.8.8
-        - 8.8.4.4
-
-  - name: pull-cert-manager-istio-csr-istio-v1-24
-    decorate: true
-    always_run: true
-    labels:
-      preset-go-cache: "true"
-      preset-local-cache: "true"
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-        args:
-        - runner
-        - make
-        - vendor-go
-        - test-e2e
-        resources:
-          requests:
-            cpu: 3500m
-            memory: 6Gi
-        env:
-        - name: ISTIO_VERSION
-          value: "1.24.0-alpha.0"
         securityContext:
           privileged: true
           capabilities:

--- a/config/testgrid/dashboards.yaml
+++ b/config/testgrid/dashboards.yaml
@@ -17,3 +17,4 @@ dashboards:
 - name: cert-manager-periodics-release-1.16
 - name: cert-manager-presubmits-master
 - name: cert-manager-testing-janitors
+- name: istio-csr-periodics


### PR DESCRIPTION
1. Removes old versions of istio (all are EOL and not supported since at least Apr 2024)
2. Adds a periodic test of istio-csr against the latest version of istio. I've not been able to e2e test the syntax I've used but I've roughly been able to approximate prow locally and it seemed OK.