### PR TITLE
Add dashboard group for istio-csr, fix comment

### DIFF
--- a/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-periodics.yaml
+++ b/config/jobs/cert-manager/istio-csr/cert-manager-istio-csr-periodics.yaml
@@ -6,6 +6,8 @@ periodics:
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
     testgrid-create-job-group: "true"
     testgrid-dashboards: istio-csr-periodics
+    testgrid-num-failures-to-alert: "2"
+    testgrid-alert-stale-results-hours: "24"
   labels:
     preset-go-cache: "true"
     preset-local-cache: "true"
@@ -34,4 +36,4 @@ periodics:
   - org: cert-manager
     repo: istio-csr
     base_ref: main
-  cron: 42 */12 * * * # run at 13:42 and 01:42 every day
+  cron: 42 */12 * * * # run at 12:42 UTC and 00:42 UTC every day (42 was picked arbitrarily)

--- a/config/testgrid/dashboards.yaml
+++ b/config/testgrid/dashboards.yaml
@@ -8,6 +8,9 @@ dashboard_groups:
   - cert-manager-periodics-release-1.16
   - cert-manager-presubmits-master
   - cert-manager-testing-janitors
+- name: cert-manager-subprojects
+  dashboard_names:
+  - istio-csr-periodics
 
 # Dashboards
 dashboards:


### PR DESCRIPTION
- Adds a couple of annotations which seem obvious (see https://github.com/kubernetes/test-infra/blob/master/testgrid/config.md)
- Fixes times given in comment on cron field; I mistakenly used BST rather than UTC
-  Moves the new istio-csr dashboard to a group called "cert-manager-subprojects"