### PR TITLE
add trust-manager to periodic-testing Prow jobs

### DIFF
--- a/config/jobs/testing/testing-periodics-trusted.yaml
+++ b/config/jobs/testing/testing-periodics-trusted.yaml
@@ -17,7 +17,7 @@ periodics:
       - commenter
       args:
       - |-
-        --query=repo:cert-manager/cert-manager
+        --query=repo:cert-manager/cert-manager repo:cert-manager/trust-manager
         -label:lifecycle/frozen
         label:lifecycle/rotten
       - --updated=720h
@@ -47,7 +47,7 @@ periodics:
       - commenter
       args:
       - |-
-        --query=repo:cert-manager/cert-manager
+        --query=repo:cert-manager/cert-manager repo:cert-manager/trust-manager
         -label:lifecycle/frozen
         label:lifecycle/stale
         -label:lifecycle/rotten
@@ -80,7 +80,7 @@ periodics:
       - commenter
       args:
       - |-
-        --query=repo:cert-manager/cert-manager
+        --query=repo:cert-manager/cert-manager repo:cert-manager/trust-manager
         -label:lifecycle/frozen
         -label:lifecycle/stale
         -label:lifecycle/rotten


### PR DESCRIPTION
To keep the community focused on the most important (and popular/fresh) issues and pull requests, I propose including trust-manager in the periodic-testing Prow jobs that run for cert-manager.