### PR TITLE
Update tests on master in preparation for 1.17 beta

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -70,57 +70,6 @@ presubmits:
     - master
     always_run: true
     optional: false
-  - name: pull-cert-manager-master-e2e-v1-28
-    max_concurrency: 4
-    decorate: true
-    annotations:
-      description: Runs the end-to-end test suite against a Kubernetes v1.28 cluster
-      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-      testgrid-create-job-group: "true"
-      testgrid-dashboards: cert-manager-presubmits-master
-    labels:
-      preset-cloudflare-credentials: "true"
-      preset-dind-enabled: "true"
-      preset-enable-all-feature-gates: "true"
-      preset-ginkgo-skip-default: "true"
-      preset-go-cache: "true"
-      preset-local-cache: "true"
-      preset-retry-flakey-jobs: "true"
-    spec:
-      containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-        args:
-        - runner
-        - make
-        - -j7
-        - vendor-go
-        - e2e-ci
-        - K8S_VERSION=1.28
-        resources:
-          requests:
-            cpu: 7000m
-            memory: 6Gi
-        securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
-      dnsPolicy: None
-      dnsConfig:
-        nameservers:
-        - 8.8.8.8
-        - 8.8.4.4
-    branches:
-    - master
-    always_run: false
-    optional: true
   - name: pull-cert-manager-master-e2e-v1-29
     max_concurrency: 4
     decorate: true
@@ -272,9 +221,60 @@ presubmits:
         - 8.8.4.4
     branches:
     - master
+    always_run: false
+    optional: true
+  - name: pull-cert-manager-master-e2e-v1-32
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.32 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-job-group: "true"
+      testgrid-dashboards: cert-manager-presubmits-master
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.32
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - make kind-logs
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - master
     always_run: true
     optional: false
-  - name: pull-cert-manager-master-e2e-v1-31-upgrade
+  - name: pull-cert-manager-master-e2e-v1-32-upgrade
     max_concurrency: 4
     decorate: true
     annotations:
@@ -292,7 +292,7 @@ presubmits:
         args:
         - runner
         - make
-        - K8S_VERSION=1.31
+        - K8S_VERSION=1.32
         - vendor-go
         - test-upgrade
         resources:
@@ -347,7 +347,7 @@ presubmits:
     always_run: false
     optional: true
     run_if_changed: go.mod
-  - name: pull-cert-manager-master-e2e-v1-31-issuers-venafi-tpp
+  - name: pull-cert-manager-master-e2e-v1-32-issuers-venafi-tpp
     max_concurrency: 4
     decorate: true
     annotations:
@@ -371,7 +371,7 @@ presubmits:
         - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.31
+        - K8S_VERSION=1.32
         resources:
           requests:
             cpu: 7000m
@@ -397,7 +397,7 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-31-issuers-venafi-cloud
+  - name: pull-cert-manager-master-e2e-v1-32-issuers-venafi-cloud
     max_concurrency: 4
     decorate: true
     annotations:
@@ -421,7 +421,7 @@ presubmits:
         - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.31
+        - K8S_VERSION=1.32
         resources:
           requests:
             cpu: 7000m
@@ -447,7 +447,7 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-31-feature-gates-disabled
+  - name: pull-cert-manager-master-e2e-v1-32-feature-gates-disabled
     max_concurrency: 4
     decorate: true
     annotations:
@@ -472,7 +472,7 @@ presubmits:
         - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.31
+        - K8S_VERSION=1.32
         resources:
           requests:
             cpu: 7000m
@@ -498,7 +498,7 @@ presubmits:
     - master
     always_run: false
     optional: true
-  - name: pull-cert-manager-master-e2e-v1-31-bestpractice-install
+  - name: pull-cert-manager-master-e2e-v1-32-bestpractice-install
     max_concurrency: 4
     decorate: true
     annotations:
@@ -525,7 +525,7 @@ presubmits:
         - -j7
         - vendor-go
         - e2e-ci
-        - K8S_VERSION=1.31
+        - K8S_VERSION=1.32
         resources:
           requests:
             cpu: 7000m
@@ -586,58 +586,6 @@ periodics:
     repo: cert-manager
     base_ref: master
   cron: 00 00-23/02 * * *
-- name: ci-cert-manager-master-e2e-v1-28
-  max_concurrency: 4
-  decorate: true
-  annotations:
-    description: Runs the end-to-end test suite against a Kubernetes v1.28 cluster
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-master
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-dind-enabled: "true"
-    preset-enable-all-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-go-cache: "true"
-    preset-local-cache: "true"
-    preset-retry-flakey-jobs: "true"
-  spec:
-    containers:
-    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-      args:
-      - runner
-      - make
-      - -j7
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.28
-      resources:
-        requests:
-          cpu: 7000m
-          memory: 6Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsPolicy: None
-    dnsConfig:
-      nameservers:
-      - 8.8.8.8
-      - 8.8.4.4
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  cron: 04 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-29
   max_concurrency: 4
   decorate: true
@@ -689,7 +637,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 08 00-23/02 * * *
+  cron: 04 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-30
   max_concurrency: 4
   decorate: true
@@ -741,7 +689,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 12 01-23/02 * * *
+  cron: 08 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-31
   max_concurrency: 4
   decorate: true
@@ -793,8 +741,60 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
+  cron: 12 01-23/02 * * *
+- name: ci-cert-manager-master-e2e-v1-32
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.32 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-master
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.32
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
   cron: 16 00-23/02 * * *
-- name: ci-cert-manager-master-e2e-v1-31-issuers-venafi
+- name: ci-cert-manager-master-e2e-v1-32-issuers-venafi
   max_concurrency: 4
   decorate: true
   annotations:
@@ -819,7 +819,7 @@ periodics:
       - -j7
       - vendor-go
       - e2e-ci
-      - K8S_VERSION=1.31
+      - K8S_VERSION=1.32
       resources:
         requests:
           cpu: 7000m
@@ -846,7 +846,7 @@ periodics:
     repo: cert-manager
     base_ref: master
   cron: 20 00-23/12 * * *
-- name: ci-cert-manager-master-e2e-v1-31-upgrade
+- name: ci-cert-manager-master-e2e-v1-32-upgrade
   max_concurrency: 4
   decorate: true
   annotations:
@@ -864,7 +864,7 @@ periodics:
       args:
       - runner
       - make
-      - K8S_VERSION=1.31
+      - K8S_VERSION=1.32
       - vendor-go
       - test-upgrade
       resources:
@@ -886,7 +886,7 @@ periodics:
     repo: cert-manager
     base_ref: master
   cron: 24 00-23/08 * * *
-- name: ci-cert-manager-master-e2e-v1-31-bestpractice-install
+- name: ci-cert-manager-master-e2e-v1-32-bestpractice-install
   max_concurrency: 4
   decorate: true
   annotations:
@@ -913,7 +913,7 @@ periodics:
       - -j7
       - vendor-go
       - e2e-ci
-      - K8S_VERSION=1.31
+      - K8S_VERSION=1.32
       resources:
         requests:
           cpu: 7000m
@@ -940,58 +940,6 @@ periodics:
     repo: cert-manager
     base_ref: master
   cron: 28 00-23/24 * * *
-- name: ci-cert-manager-master-e2e-v1-28-feature-gates-disabled
-  max_concurrency: 4
-  decorate: true
-  annotations:
-    description: Runs the E2E tests with all feature gates disabled
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    testgrid-create-job-group: "true"
-    testgrid-dashboards: cert-manager-periodics-master
-  labels:
-    preset-cloudflare-credentials: "true"
-    preset-dind-enabled: "true"
-    preset-disable-all-alpha-beta-feature-gates: "true"
-    preset-ginkgo-skip-default: "true"
-    preset-go-cache: "true"
-    preset-local-cache: "true"
-    preset-retry-flakey-jobs: "true"
-  spec:
-    containers:
-    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
-      args:
-      - runner
-      - make
-      - -j7
-      - vendor-go
-      - e2e-ci
-      - K8S_VERSION=1.28
-      resources:
-        requests:
-          cpu: 7000m
-          memory: 6Gi
-      securityContext:
-        privileged: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
-    dnsPolicy: None
-    dnsConfig:
-      nameservers:
-      - 8.8.8.8
-      - 8.8.4.4
-  extra_refs:
-  - org: cert-manager
-    repo: cert-manager
-    base_ref: master
-  cron: 32 07-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-29-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1043,7 +991,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 36 14-23/24 * * *
+  cron: 32 07-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-30-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1095,7 +1043,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 40 21-23/24 * * *
+  cron: 36 14-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-31-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1122,6 +1070,58 @@ periodics:
       - vendor-go
       - e2e-ci
       - K8S_VERSION=1.31
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+      lifecycle:
+        preStop:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - make kind-logs
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  cron: 40 21-23/24 * * *
+- name: ci-cert-manager-master-e2e-v1-32-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-master
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.32
       resources:
         requests:
           cpu: 7000m

--- a/config/prowgen/prowspecs/specs.go
+++ b/config/prowgen/prowspecs/specs.go
@@ -120,8 +120,8 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 			Repo: "cert-manager",
 		},
 
-		primaryKubernetesVersion: "1.31",
-		otherKubernetesVersions:  []string{"1.28", "1.29", "1.30"},
+		primaryKubernetesVersion: "1.32",
+		otherKubernetesVersions:  []string{"1.29", "1.30", "1.31"},
 
 		e2eCPURequest:    "7000m",
 		e2eMemoryRequest: "6Gi",


### PR DESCRIPTION
See https://github.com/cert-manager/website/pull/1627 for details about what k8s versions cert-manager 1.17 will support.