### PR TITLE
Update image locations due to upstream changed registries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ test:
 local-checkconfig:
 	docker run --rm \
 		-v $(CURDIR)/config:/config \
-		gcr.io/k8s-prow/checkconfig:v20230407-e8b3bf711e \
+		us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20240802-66b115076 \
 		--strict=true \
         --config-path=/config/config.yaml \
         --job-config-path=/config/jobs \
@@ -46,7 +46,7 @@ local-checkconfig:
 
 	docker run --rm \
 		-v $(CURDIR)/config:/config \
-		gcr.io/k8s-prow/configurator:v20230407-e8b3bf711e \
+		gcr.io/k8s-staging-test-infra/configurator:v20250306-095fc63a16 \
         --yaml=/config/testgrid/dashboards.yaml \
         --default=config/testgrid/default.yaml \
         --prow-config=/config/config.yaml \

--- a/config/autobump-config/testing-autobump-config.yaml
+++ b/config/autobump-config/testing-autobump-config.yaml
@@ -18,8 +18,13 @@ extraFiles:
   - "config/prowgen/pkg/globals.go"
 targetVersion: "latest"
 prefixes:
-  - name: "k8s-prow images"
-    prefix: "gcr.io/k8s-prow/"
+  - name: "k8s-infra-prow images"
+    prefix: "us-docker.pkg.dev/k8s-infra-prow/images/"
+    repo: "https://github.com/kubernetes-sigs/prow"
+    summarise: false
+    consistentImages: false
+  - name: "k8s-staging-test-infra images"
+    prefix: "gcr.io/k8s-staging-test-infra/"
     repo: "https://github.com/kubernetes/test-infra"
     summarise: false
     consistentImages: false

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -12,10 +12,10 @@ plank:
       timeout: 7200000000000 # 2h
       grace_period: 10000000000 # 10s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20240805-37a08f946"
-        initupload: "gcr.io/k8s-prow/initupload:v20240805-37a08f946"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20240805-37a08f946"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20240805-37a08f946"
+        clonerefs: "us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20240805-37a08f946"
+        initupload: "us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20240805-37a08f946"
+        entrypoint: "us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20240805-37a08f946"
+        sidecar: "us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20240805-37a08f946"
       gcs_configuration:
         bucket: cert-manager-prow-artifacts
         path_strategy: explicit

--- a/config/jobs/testing/testing-periodics-trusted.yaml
+++ b/config/jobs/testing/testing-periodics-trusted.yaml
@@ -12,7 +12,7 @@ periodics:
     preset-deployer-github-token: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20250306-095fc63a16
       command:
       - commenter
       args:
@@ -42,7 +42,7 @@ periodics:
     preset-deployer-github-token: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20250306-095fc63a16
       command:
       - commenter
       args:
@@ -75,7 +75,7 @@ periodics:
     preset-deployer-github-token: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20240731-a5d9345e59
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20250306-095fc63a16
       command:
       - commenter
       args:
@@ -112,7 +112,7 @@ periodics:
     preset-deployer-ssh-key: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20240805-37a08f946
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20240802-66b115076
       command:
       - generic-autobumper
       args:
@@ -134,7 +134,7 @@ periodics:
   spec:
     containers:
     - name: label-sync
-      image: gcr.io/k8s-prow/label_sync:v20240731-a5d9345e59
+      image: gcr.io/k8s-staging-test-infra/label_sync:v20241009-8bb28ed95b
       command:
       - label_sync
       args:
@@ -179,7 +179,7 @@ periodics:
   spec:
     containers:
     - name: branchprotector
-      image: gcr.io/k8s-prow/branchprotector:v20240805-37a08f946
+      image: us-docker.pkg.dev/k8s-infra-prow/images/branchprotector:v20240805-37a08f946
       command:
       - branchprotector
       args:

--- a/config/jobs/testing/testing-postsubmits-trusted.yaml
+++ b/config/jobs/testing/testing-postsubmits-trusted.yaml
@@ -22,7 +22,7 @@ postsubmits:
     spec:
       serviceAccountName: testgrid-updater
       containers:
-      - image: gcr.io/k8s-prow/configurator:v20240731-a5d9345e59
+      - image: gcr.io/k8s-staging-test-infra/configurator:v20250306-095fc63a16
         command:
         - configurator
         args:

--- a/config/jobs/testing/testing-presubmits.yaml
+++ b/config/jobs/testing/testing-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20240805-37a08f946
+      - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20240805-37a08f946
         command:
         - checkconfig
         args:
@@ -65,7 +65,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-prow/configurator:v20240731-a5d9345e59
+      - image: gcr.io/k8s-staging-test-infra/configurator:v20250306-095fc63a16
         command:
         - configurator
         args:

--- a/images/README.md
+++ b/images/README.md
@@ -28,7 +28,7 @@ To get the image built for the first time you can either merge the postsubmit jo
 From the root of this repository run:
 
 ```bash
-docker run -it -v$(pwd):/testing gcr.io/k8s-prow/mkpj --job=NAME_OF_YOUR_POSTSUBMIT_JOB--config-path=/testing/config/config.yaml --job-config-path=/testing/config/jobs/testing/testing-trusted.yaml --base-ref=master
+docker run -it -v$(pwd):/testing us-docker.pkg.dev/k8s-infra-prow/images/mkpj --job=NAME_OF_YOUR_POSTSUBMIT_JOB--config-path=/testing/config/config.yaml --job-config-path=/testing/config/jobs/testing/testing-trusted.yaml --base-ref=master
 ```
 
 This command will output a ProwJob config that you can apply to [build infra cluster](../prow/README.md)

--- a/prow/cert-manager_install.sh
+++ b/prow/cert-manager_install.sh
@@ -21,8 +21,6 @@ helm upgrade \
     --reset-values \
     --namespace cert-manager \
     --create-namespace \
-    --version v1.15.1 \
+    --version v1.17.1 \
     --set crds.enabled=true \
-    --set config.apiVersion="controller.config.cert-manager.io/v1alpha1" \
-    --set config.kind="ControllerConfiguration" \
     --set config.enableGatewayAPI="true"

--- a/prow/cluster/cherrypicker_deployment.yaml
+++ b/prow/cluster/cherrypicker_deployment.yaml
@@ -39,7 +39,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/cherrypicker:v20240805-37a08f946
         imagePullPolicy: Always
         args:
         - --github-token-path=/etc/github/token
@@ -68,9 +68,9 @@ spec:
       # We cannot use the GitHub APP here because
       # an APP does not have any repos, and can thus not
       # have/ create a fork of a repo to create a cherrypick.
-      - name: github-app-token
-        secret:
-          secretName: github-app-token
+      # - name: github-app-token
+      #   secret:
+      #     secretName: github-app-token
       - name: github-token
         secret:
           secretName: cert-manager-bot-github-token

--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/crier:v20240805-37a08f946
         args:
         - --blob-storage-workers=10
         - --config-path=/etc/config/config.yaml

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/deck:v20240805-37a08f946
         imagePullPolicy: Always
         ports:
         - name: http

--- a/prow/cluster/ghproxy.yaml
+++ b/prow/cluster/ghproxy.yaml
@@ -59,7 +59,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20240805-37a08f946
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/hook:v20240805-37a08f946
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/horologium:v20240805-37a08f946
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/needs-rebase:v20240805-37a08f946
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        image: gcr.io/k8s-prow/sinker:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/sinker:v20240805-37a08f946
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG

--- a/prow/cluster/statusreconciler_deployment.yaml
+++ b/prow/cluster/statusreconciler_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/status-reconciler:v20240805-37a08f946
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/tide:v20240805-37a08f946
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/prow/cluster/tot_deployment.yaml
+++ b/prow/cluster/tot_deployment.yaml
@@ -47,7 +47,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: tot
-        image: gcr.io/k8s-prow/tot:v20240805-37a08f946
+        image: us-docker.pkg.dev/k8s-infra-prow/images/tot:v20240805-37a08f946
         imagePullPolicy: Always
         args:
         - -storage=/store/tot.json

--- a/prow/mkpj.sh
+++ b/prow/mkpj.sh
@@ -33,11 +33,11 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 config="${root}/config/config.yaml"
 job_config_path="${root}/config/jobs"
 
-docker pull gcr.io/k8s-prow/mkpj 1>&2 || true
+docker pull us-docker.pkg.dev/k8s-infra-prow/images/mkpj 1>&2 || true
 docker run \
        -i --rm \
        --user "$(id -u):$(id -g)" \
        -v "${root}:${root}" \
        --security-opt="label=disable" \
-       gcr.io/k8s-prow/mkpj \
+       us-docker.pkg.dev/k8s-infra-prow/images/mkpj \
        "--config-path=${config}" "--job-config-path=${job_config_path}" "$@"

--- a/prow/pj-on-kind.sh
+++ b/prow/pj-on-kind.sh
@@ -39,10 +39,10 @@ function main() {
   ensureInstall
 
   # Generate PJ and Pod.
-  docker pull gcr.io/k8s-prow/mkpj:latest
-  docker run -i --rm --user "$(id -u):$(id -g)" -v "${PWD}:${PWD}" -v "${config}:${config}" ${job_config_mnt} -w "${PWD}" gcr.io/k8s-prow/mkpj:latest "--config-path=${config}" "--job=${job}" ${job_config_flag} > "${PWD}/pj.yaml"
-  docker pull gcr.io/k8s-prow/mkpod:latest
-  docker run -i --rm --user "$(id -u):$(id -g)" -v "${PWD}:${PWD}" -w "${PWD}" gcr.io/k8s-prow/mkpod:latest --build-id=snowflake "--prow-job=${PWD}/pj.yaml" --local "--out-dir=${out_dir}/${job}" > "${PWD}/pod.yaml"
+  docker pull us-docker.pkg.dev/k8s-infra-prow/images/mkpj:latest
+  docker run -i --rm --user "$(id -u):$(id -g)" -v "${PWD}:${PWD}" -v "${config}:${config}" ${job_config_mnt} -w "${PWD}" us-docker.pkg.dev/k8s-infra-prow/images/mkpj:latest "--config-path=${config}" "--job=${job}" ${job_config_flag} > "${PWD}/pj.yaml"
+  docker pull us-docker.pkg.dev/k8s-infra-prow/images/mkpod:latest
+  docker run -i --rm --user "$(id -u):$(id -g)" -v "${PWD}:${PWD}" -w "${PWD}" us-docker.pkg.dev/k8s-infra-prow/images/mkpod:latest --build-id=snowflake "--prow-job=${PWD}/pj.yaml" --local "--out-dir=${out_dir}/${job}" > "${PWD}/pod.yaml"
 
   # Add any k8s resources that the pod depends on to the kind cluster here. (secrets, configmaps, etc.)
 


### PR DESCRIPTION
See upstream PRs:
- https://github.com/kubernetes/test-infra/pull/33210
- https://github.com/kubernetes/test-infra/pull/33206

Replaces all usages of the deprecated `gcr.io/k8s-prow` location.

I manually applied the changes to the prow cluster and everything still seems to be working.