### PR TITLE
Upgrade image variants

### DIFF
--- a/images/golang-dind/build.yaml
+++ b/images/golang-dind/build.yaml
@@ -1,14 +1,10 @@
 name: golang-dind # Name of the image to be built
 
 variants:
-  "1.22":
+  "1.24":
     arguments:
       BASE_IMAGE: "europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm"
-      GO_VERSION: "1.22.2"
-  "1.21":
-    arguments:
-      BASE_IMAGE: "europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20240422-6b43e85-bookworm"
-      GO_VERSION: "1.21.9"
+      GO_VERSION: "1.24.1"
 
 # Image names to be tagged and pushed
 images:

--- a/images/image-builder/build.yaml
+++ b/images/image-builder/build.yaml
@@ -1,10 +1,10 @@
 name: image-builder # Name of the image to be built
 
 variants:
-  gcloud-425:
+  gcloud-516:
     arguments:
       BASE_IMAGE: "europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240422-729441b-1.22"
-      CLOUD_SDK_VERSION: "425.0.0"
+      CLOUD_SDK_VERSION: "516.0.0"
 
 # Image names to be tagged and pushed
 images:

--- a/images/make-dind/build.yaml
+++ b/images/make-dind/build.yaml
@@ -6,7 +6,7 @@ variants:
   bookworm:
     arguments:
       DEBIAN_VERSION: bookworm-slim
-      DOCKER_VERSION: 5:26.0.1-1~debian.12~bookworm
+      DOCKER_VERSION: 5:28.0.4-1~debian.12~bookworm
 
 # Image names to be tagged and pushed
 images:


### PR DESCRIPTION
Bumping a few of the image variant parameters.
Next, image builds will get triggered and the autobumper will bump these images in the configurations.