### PR TITLE
Switch to golang-dind 1.24 and image-builder gcloud-516

### DIFF
--- a/config/jobs/cert-manager/boilersuite/cert-manager-boilersuite.yaml
+++ b/config/jobs/cert-manager/boilersuite/cert-manager-boilersuite.yaml
@@ -9,7 +9,7 @@ presubmits:
     labels:
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240422-729441b-1.22
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20250327-a3af8ba-1.24
         args:
         - runner
         - make

--- a/config/jobs/cert-manager/org/org-presubmits.yaml
+++ b/config/jobs/cert-manager/org/org-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240422-729441b-1.22
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20250327-a3af8ba-1.24
         args:
         - runner
         - make

--- a/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
+++ b/config/jobs/cert-manager/release/cert-manager-release-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     labels:
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240422-729441b-1.22
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20250327-a3af8ba-1.24
         args:
         - runner
         - make

--- a/config/jobs/cert-manager/webhook-example/cert-manager-webhook-example-presubmits.yaml
+++ b/config/jobs/cert-manager/webhook-example/cert-manager-webhook-example-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240422-729441b-1.22
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20250327-a3af8ba-1.24
         args:
         - make
         - test

--- a/config/jobs/testing/testing-postsubmits-trusted.yaml
+++ b/config/jobs/testing/testing-postsubmits-trusted.yaml
@@ -57,7 +57,7 @@ postsubmits:
       description: Build and push the 'gencred' image
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/image-builder:20240422-8a629d9-gcloud-425
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/image-builder:20250327-af35b2b-gcloud-516
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner
@@ -92,7 +92,7 @@ postsubmits:
       description: Build and push the 'prow-controller-manager-spot' image
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/image-builder:20240422-8a629d9-gcloud-425
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/image-builder:20250327-af35b2b-gcloud-516
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner
@@ -127,7 +127,7 @@ postsubmits:
       description: Build and push the 'make-dind' image
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/image-builder:20240422-8a629d9-gcloud-425
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/image-builder:20250327-af35b2b-gcloud-516
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner
@@ -162,7 +162,7 @@ postsubmits:
       description: Build and push the 'golang-dind' image
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/image-builder:20240422-8a629d9-gcloud-425
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/image-builder:20250327-af35b2b-gcloud-516
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner
@@ -197,7 +197,7 @@ postsubmits:
       description: Build and push the 'image-builder' image
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/image-builder:20240422-8a629d9-gcloud-425
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/image-builder:20250327-af35b2b-gcloud-516
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner
@@ -232,7 +232,7 @@ postsubmits:
       description: Build and push the 'kind' image
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240422-729441b-1.22
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20250327-a3af8ba-1.24
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner
@@ -264,7 +264,7 @@ postsubmits:
       description: Build and push the 'golang-aws' image
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/image-builder:20240422-8a629d9-gcloud-425
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/image-builder:20250327-af35b2b-gcloud-516
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner
@@ -299,7 +299,7 @@ postsubmits:
       description: Build and push the 'nix-dind' image
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/image-builder:20240422-8a629d9-gcloud-425
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/image-builder:20250327-af35b2b-gcloud-516
         args:
         # Wrap the release script with the runner so we can use docker-in-docker
         - runner

--- a/config/jobs/testing/testing-presubmits.yaml
+++ b/config/jobs/testing/testing-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240422-729441b-1.22
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20250327-a3af8ba-1.24
         args:
         - runner
         - make
@@ -47,7 +47,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240422-729441b-1.22
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20250327-a3af8ba-1.24
         args:
         - runner
         - make

--- a/images/gencred/build.yaml
+++ b/images/gencred/build.yaml
@@ -3,7 +3,7 @@ name: gencred # Name of the image to be built
 variants:
   latest:
     arguments:
-      BUILDER_IMAGE: "europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240422-729441b-1.22"
+      BUILDER_IMAGE: "europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20250327-a3af8ba-1.24"
       BASE_IMAGE: "quay.io/jetstack/base-static@sha256:ba3cff0a4cacc5ae564e04c1f645000e8c9234c0f4b09534be1dee7874a42141"
 
 # Image names to be tagged and pushed

--- a/images/image-builder/build.yaml
+++ b/images/image-builder/build.yaml
@@ -3,7 +3,7 @@ name: image-builder # Name of the image to be built
 variants:
   gcloud-516:
     arguments:
-      BASE_IMAGE: "europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240422-729441b-1.22"
+      BASE_IMAGE: "europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20250327-a3af8ba-1.24"
       CLOUD_SDK_VERSION: "516.0.0"
 
 # Image names to be tagged and pushed

--- a/images/prow-controller-manager-spot/build.yaml
+++ b/images/prow-controller-manager-spot/build.yaml
@@ -3,7 +3,7 @@ name: prow-controller-manager-spot # Name of the image to be built
 variants:
   latest:
     arguments:
-      BUILDER_IMAGE: "europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20240422-729441b-1.22"
+      BUILDER_IMAGE: "europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/golang-dind:20250327-a3af8ba-1.24"
       BASE_IMAGE: "quay.io/jetstack/base-static@sha256:ba3cff0a4cacc5ae564e04c1f645000e8c9234c0f4b09534be1dee7874a42141"
 
 # Image names to be tagged and pushed


### PR DESCRIPTION
Switches images to the new variants we created in https://github.com/cert-manager/testing/pull/1079.