### PR TITLE
use executable mount on host system

### DIFF
--- a/config/jobs/cert-manager/config.yaml
+++ b/config/jobs/cert-manager/config.yaml
@@ -168,7 +168,9 @@ presets:
   volumes:
     - name: shared-cache
       hostPath:
-        path: /mnt/stateful_partition/cache/shared_cache
+        # Use an on-disk folder which is mounted with executable permissions.
+        # See https://cloud.google.com/container-optimized-os/docs/concepts/disks-and-filesystem
+        path: /var/lib/toolbox/cache/shared_cache
         type: DirectoryOrCreate
 
 - labels:
@@ -186,11 +188,15 @@ presets:
   volumes:
     - name: go-cache
       hostPath:
-        path: /mnt/stateful_partition/cache/go_cache
+        # Use an on-disk folder which is mounted with executable permissions.
+        # See https://cloud.google.com/container-optimized-os/docs/concepts/disks-and-filesystem
+        path: /var/lib/toolbox/cache/go_cache
         type: DirectoryOrCreate
     - name: go-mod-cache
       hostPath:
-        path: /mnt/stateful_partition/cache/go_mod_cache
+        # Use an on-disk folder which is mounted with executable permissions.
+        # See https://cloud.google.com/container-optimized-os/docs/concepts/disks-and-filesystem
+        path: /var/lib/toolbox/cache/go_mod_cache
         type: DirectoryOrCreate
 
 # A preset which causes make e2e-setup to install cert-manager in accordance


### PR DESCRIPTION
We are seeing this error:
```
fork/exec /root/.prow_go_cache/da/da4b2d14b15a12442965ea1840533e804a4cc6e3c642f35906189853809909da-d/main: permission denied
```

This seems to be caused by the `/mnt/stateful_partition` host mount not being mounted as executable.
Instead, we can use the `/var/lib/toolbox` host mount which IS mounted as executable (see https://cloud.google.com/container-optimized-os/docs/concepts/disks-and-filesystem).