### PR TITLE
Remove preStop lifecycle hook

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -105,13 +105,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -156,13 +149,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -207,13 +193,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -330,13 +309,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -380,13 +352,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -431,13 +396,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -484,13 +442,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -570,13 +521,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -622,13 +566,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -674,13 +611,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -726,13 +656,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -820,13 +743,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -872,13 +788,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -924,13 +833,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -976,13 +878,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:

--- a/config/jobs/cert-manager/cert-manager/release-1.12/cert-manager-release-1.12.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.12/cert-manager-release-1.12.yaml
@@ -99,13 +99,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -147,13 +140,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -195,13 +181,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -243,13 +222,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -291,13 +263,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -339,13 +304,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -387,13 +345,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -435,13 +386,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -549,13 +493,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -596,13 +533,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -644,13 +574,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -694,13 +617,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -781,13 +697,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -833,13 +742,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -885,13 +787,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -937,13 +832,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -989,13 +877,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -1041,13 +922,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -1093,13 +967,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -1145,13 +1012,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -1197,13 +1057,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -1291,13 +1144,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -1343,13 +1189,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -1395,13 +1234,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -1447,13 +1279,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -1499,13 +1324,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -1551,13 +1369,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -1603,13 +1414,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -1655,13 +1459,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -1707,13 +1504,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:

--- a/config/jobs/cert-manager/cert-manager/release-1.16/cert-manager-release-1.16.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.16/cert-manager-release-1.16.yaml
@@ -96,13 +96,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -144,13 +137,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -192,13 +178,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -240,13 +219,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -288,13 +260,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -402,13 +367,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -449,13 +407,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -497,13 +448,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -547,13 +491,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -633,13 +570,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -685,13 +615,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -737,13 +660,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -789,13 +705,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -841,13 +750,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -893,13 +795,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -987,13 +882,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -1039,13 +927,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -1091,13 +972,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -1143,13 +1017,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -1195,13 +1062,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -1247,13 +1107,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:

--- a/config/jobs/cert-manager/cert-manager/release-1.17/cert-manager-release-1.17.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.17/cert-manager-release-1.17.yaml
@@ -96,13 +96,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -144,13 +137,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -192,13 +178,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -240,13 +219,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -354,13 +326,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -401,13 +366,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -449,13 +407,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -499,13 +450,6 @@ presubmits:
           capabilities:
             add:
             - SYS_ADMIN
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - make kind-logs
       dnsPolicy: None
       dnsConfig:
         nameservers:
@@ -585,13 +529,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -637,13 +574,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -689,13 +619,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -741,13 +664,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -793,13 +709,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -887,13 +796,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -939,13 +841,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -991,13 +886,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -1043,13 +931,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:
@@ -1095,13 +976,6 @@ periodics:
         capabilities:
           add:
           - SYS_ADMIN
-      lifecycle:
-        preStop:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - make kind-logs
     dnsPolicy: None
     dnsConfig:
       nameservers:

--- a/config/prowgen/pkg/generators.go
+++ b/config/prowgen/pkg/generators.go
@@ -245,17 +245,6 @@ func E2ETest(ctx *ProwContext, k8sVersion string, cpuRequest, memoryRequest stri
 					Add: []string{"SYS_ADMIN"},
 				},
 			},
-			Lifecycle: &Lifecycle{
-				PreStop: LifecycleHandler{
-					Exec: ExecAction{
-						Command: []string{
-							"/bin/sh",
-							"-c",
-							"make kind-logs",
-						},
-					},
-				},
-			},
 		},
 	}
 

--- a/config/prowgen/pkg/types.go
+++ b/config/prowgen/pkg/types.go
@@ -56,8 +56,6 @@ type Container struct {
 	Resources ContainerResources `yaml:"resources"`
 
 	SecurityContext *SecurityContext `yaml:"securityContext,omitempty"`
-
-	Lifecycle *Lifecycle `yaml:"lifecycle,omitempty"`
 }
 
 type ContainerResources struct {
@@ -86,18 +84,6 @@ type SecurityContext struct {
 
 type SecurityContextCapabilities struct {
 	Add []string `yaml:"add"`
-}
-
-type Lifecycle struct {
-	PreStop LifecycleHandler `yaml:"preStop"`
-}
-
-type LifecycleHandler struct {
-	Exec ExecAction `yaml:"exec"`
-}
-
-type ExecAction struct {
-	Command []string `yaml:"command"`
 }
 
 type PresubmitJob struct {


### PR DESCRIPTION
This hook was added in https://github.com/cert-manager/testing/pull/748 and automated in https://github.com/cert-manager/release/pull/98.

However, `preStop` lifecycle hooks don't have access to the container's environment variables (see https://stackoverflow.com/questions/61929055/kubernetes-prestop-hook-doesnt-work-with-env-variables). This is however required to write to the right `${ARTIFACTS}` location. This means that this hook was never functioning correctly (it just outputted the logs to the wrong directory). Instead, we should handle this in the entrypoint or make target.