### PR TITLE
Allow optional testing with Kubernetes 1.33

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -158,6 +158,50 @@ presubmits:
     - master
     always_run: false
     optional: true
+  - name: pull-cert-manager-master-e2e-v1-33
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.33 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-job-group: "true"
+      testgrid-dashboards: cert-manager-presubmits-master
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20250327-af35b2b-bookworm
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.33
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - master
+    always_run: false
+    optional: true
   - name: pull-cert-manager-master-e2e-v1-32
     max_concurrency: 4
     decorate: true
@@ -576,6 +620,51 @@ periodics:
     repo: cert-manager
     base_ref: master
   cron: 08 00-23/02 * * *
+- name: ci-cert-manager-master-e2e-v1-33
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.33 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-master
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20250327-af35b2b-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.33
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  cron: 12 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-32
   max_concurrency: 4
   decorate: true
@@ -620,7 +709,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 12 01-23/02 * * *
+  cron: 16 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-32-issuers-venafi
   max_concurrency: 4
   decorate: true
@@ -665,7 +754,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 16 00-23/12 * * *
+  cron: 20 00-23/12 * * *
 - name: ci-cert-manager-master-e2e-v1-32-upgrade
   max_concurrency: 4
   decorate: true
@@ -705,7 +794,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 20 00-23/08 * * *
+  cron: 24 00-23/08 * * *
 - name: ci-cert-manager-master-e2e-v1-32-bestpractice-install
   max_concurrency: 4
   decorate: true
@@ -752,7 +841,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 24 00-23/24 * * *
+  cron: 28 00-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-30-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -797,7 +886,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 28 07-23/24 * * *
+  cron: 32 07-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-31-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -842,7 +931,52 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 32 14-23/24 * * *
+  cron: 36 14-23/24 * * *
+- name: ci-cert-manager-master-e2e-v1-33-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-master
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20250327-af35b2b-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.33
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  cron: 40 21-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-32-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -887,7 +1021,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 36 21-23/24 * * *
+  cron: 44 04-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-controller
   max_concurrency: 2
   decorate: true
@@ -927,7 +1061,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 40 04-23/24 * * *
+  cron: 48 11-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-acmesolver
   max_concurrency: 2
   decorate: true
@@ -967,7 +1101,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 44 11-23/24 * * *
+  cron: 52 18-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-startupapicheck
   max_concurrency: 2
   decorate: true
@@ -1007,7 +1141,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 48 18-23/24 * * *
+  cron: 56 01-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-cainjector
   max_concurrency: 2
   decorate: true
@@ -1047,7 +1181,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 52 01-23/24 * * *
+  cron: 00 08-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-webhook
   max_concurrency: 2
   decorate: true
@@ -1087,4 +1221,4 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 56 08-23/24 * * *
+  cron: 04 15-23/24 * * *

--- a/config/jobs/cert-manager/cert-manager/release-1.18/cert-manager-release-1.18.yaml
+++ b/config/jobs/cert-manager/cert-manager/release-1.18/cert-manager-release-1.18.yaml
@@ -187,6 +187,47 @@ presubmits:
     - release-1.18
     always_run: false
     optional: true
+  - name: pull-cert-manager-release-1.18-e2e-v1-33
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.33 cluster
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20250327-af35b2b-bookworm
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.33
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - release-1.18
+    always_run: false
+    optional: true
   - name: pull-cert-manager-release-1.18-e2e-v1-32
     max_concurrency: 4
     decorate: true
@@ -629,6 +670,51 @@ periodics:
     repo: cert-manager
     base_ref: release-1.18
   cron: 15 00-23/02 * * *
+- name: ci-cert-manager-release-1.18-e2e-v1-33
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.33 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.18
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20250327-af35b2b-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.33
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.18
+  cron: 19 01-23/02 * * *
 - name: ci-cert-manager-release-1.18-e2e-v1-32
   max_concurrency: 4
   decorate: true
@@ -673,7 +759,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.18
-  cron: 19 01-23/02 * * *
+  cron: 23 00-23/02 * * *
 - name: ci-cert-manager-release-1.18-e2e-v1-32-issuers-venafi
   max_concurrency: 4
   decorate: true
@@ -718,7 +804,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.18
-  cron: 23 03-23/12 * * *
+  cron: 27 03-23/12 * * *
 - name: ci-cert-manager-release-1.18-e2e-v1-32-upgrade
   max_concurrency: 4
   decorate: true
@@ -758,7 +844,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.18
-  cron: 27 03-23/08 * * *
+  cron: 31 03-23/08 * * *
 - name: ci-cert-manager-release-1.18-e2e-v1-32-bestpractice-install
   max_concurrency: 4
   decorate: true
@@ -805,7 +891,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.18
-  cron: 31 03-23/24 * * *
+  cron: 35 03-23/24 * * *
 - name: ci-cert-manager-release-1.18-e2e-v1-29-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -850,7 +936,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.18
-  cron: 35 10-23/24 * * *
+  cron: 39 10-23/24 * * *
 - name: ci-cert-manager-release-1.18-e2e-v1-30-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -895,7 +981,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.18
-  cron: 39 17-23/24 * * *
+  cron: 43 17-23/24 * * *
 - name: ci-cert-manager-release-1.18-e2e-v1-31-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -940,7 +1026,52 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.18
-  cron: 43 00-23/24 * * *
+  cron: 47 00-23/24 * * *
+- name: ci-cert-manager-release-1.18-e2e-v1-33-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-release-1.18
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20250327-af35b2b-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.33
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: release-1.18
+  cron: 51 07-23/24 * * *
 - name: ci-cert-manager-release-1.18-e2e-v1-32-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -985,7 +1116,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.18
-  cron: 47 07-23/24 * * *
+  cron: 55 14-23/24 * * *
 - name: ci-cert-manager-release-1.18-trivy-test-controller
   max_concurrency: 2
   decorate: true
@@ -1025,7 +1156,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.18
-  cron: 51 14-23/24 * * *
+  cron: 59 21-23/24 * * *
 - name: ci-cert-manager-release-1.18-trivy-test-acmesolver
   max_concurrency: 2
   decorate: true
@@ -1065,7 +1196,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.18
-  cron: 55 21-23/24 * * *
+  cron: 03 04-23/24 * * *
 - name: ci-cert-manager-release-1.18-trivy-test-startupapicheck
   max_concurrency: 2
   decorate: true
@@ -1105,7 +1236,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.18
-  cron: 59 04-23/24 * * *
+  cron: 07 11-23/24 * * *
 - name: ci-cert-manager-release-1.18-trivy-test-cainjector
   max_concurrency: 2
   decorate: true
@@ -1145,7 +1276,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.18
-  cron: 03 11-23/24 * * *
+  cron: 11 18-23/24 * * *
 - name: ci-cert-manager-release-1.18-trivy-test-webhook
   max_concurrency: 2
   decorate: true
@@ -1185,4 +1316,4 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: release-1.18
-  cron: 07 18-23/24 * * *
+  cron: 15 01-23/24 * * *

--- a/config/prowgen/prowspecs/specs.go
+++ b/config/prowgen/prowspecs/specs.go
@@ -91,7 +91,7 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 		},
 
 		primaryKubernetesVersion: "1.32",
-		otherKubernetesVersions:  []string{"1.29", "1.30", "1.31"},
+		otherKubernetesVersions:  []string{"1.29", "1.30", "1.31", "1.33"},
 
 		e2eCPURequest:    "7000m",
 		e2eMemoryRequest: "6Gi",

--- a/config/prowgen/prowspecs/specs.go
+++ b/config/prowgen/prowspecs/specs.go
@@ -111,7 +111,7 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 		},
 
 		primaryKubernetesVersion: "1.32",
-		otherKubernetesVersions:  []string{"1.30", "1.31"},
+		otherKubernetesVersions:  []string{"1.30", "1.31", "1.33"},
 
 		e2eCPURequest:    "7000m",
 		e2eMemoryRequest: "6Gi",


### PR DESCRIPTION
This will allow me to use `/test pull-cert-manager-master-e2e-v1-33` in: 
 * https://github.com/cert-manager/cert-manager/pull/7786

If it works, I'll create another PR to add the 1.33 images to release-1.18 and  make 1.33 the default version for pull requests.