### PR TITLE
Stale bot: staleness after 6 months, close after 1 year

### DIFF
--- a/config/jobs/testing/testing-periodics-trusted.yaml
+++ b/config/jobs/testing/testing-periodics-trusted.yaml
@@ -7,7 +7,7 @@ periodics:
   annotations:
     testgrid-dashboards: cert-manager-testing-janitors
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Closes PRs and issues that are marked 'rotten' and have been inactive for 3m
+    description: Closes PRs and issues that are marked 'rotten' and have been inactive for 3 months
   labels:
     preset-deployer-github-token: "true"
   spec:
@@ -23,7 +23,7 @@ periodics:
       - --updated=2184h # 3 months
       - --token=/etc/github/token
       - |-
-        --comment=Rotten issues close after 3m of inactivity.
+        --comment=Rotten issues close after 3 months of inactivity.
         Reopen the issue with `/reopen`.
         Mark the issue as fresh with `/remove-lifecycle rotten`.
         /close
@@ -37,7 +37,7 @@ periodics:
   annotations:
     testgrid-dashboards: cert-manager-testing-janitors
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Marks PRs and issues that are marked 'stale' and have been inactive for 3m as 'rotten'
+    description: Marks PRs and issues that are marked 'stale' and have been inactive for 3 months as 'rotten'
   labels:
     preset-deployer-github-token: "true"
   spec:
@@ -56,7 +56,7 @@ periodics:
       - |-
         --comment=Stale issues rot after 3m of inactivity.
         Mark the issue as fresh with `/remove-lifecycle rotten`.
-        Rotten issues close after an additional 3m of inactivity.
+        Rotten issues close after an additional 3 months of inactivity.
         If this issue is safe to close now please do so with `/close`.
         /lifecycle rotten
         /remove-lifecycle stale
@@ -70,7 +70,7 @@ periodics:
   annotations:
     testgrid-dashboards: cert-manager-testing-janitors
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Marks PRs and issues that have been inactive for 6m as 'stale'
+    description: Marks PRs and issues that have been inactive for 6 months as 'stale'
   labels:
     preset-deployer-github-token: "true"
   spec:
@@ -87,9 +87,9 @@ periodics:
       - --updated=4368h # 6 months
       - --token=/etc/github/token
       - |-
-        --comment=Issues go stale after 6m of inactivity.
+        --comment=Issues go stale after 6 months of inactivity.
         Mark the issue as fresh with `/remove-lifecycle stale`.
-        Stale issues rot after an additional 3m of inactivity and eventually close.
+        Stale issues remain open for an additional 3 months of inactivity and then close.
         If this issue is safe to close now please do so with `/close`.
         /lifecycle stale
       - --ceiling=10

--- a/config/jobs/testing/testing-periodics-trusted.yaml
+++ b/config/jobs/testing/testing-periodics-trusted.yaml
@@ -54,7 +54,7 @@ periodics:
       - --updated=2184h # 3 months
       - --token=/etc/github/token
       - |-
-        --comment=Stale issues rot after 3m of inactivity.
+        --comment=Stale issues rot after 3 months of inactivity.
         Mark the issue as fresh with `/remove-lifecycle rotten`.
         Rotten issues close after an additional 3 months of inactivity.
         If this issue is safe to close now please do so with `/close`.

--- a/config/jobs/testing/testing-periodics-trusted.yaml
+++ b/config/jobs/testing/testing-periodics-trusted.yaml
@@ -94,3 +94,113 @@ periodics:
         /lifecycle stale
       - --ceiling=10
       - --confirm
+
+- name: periodic-testing-autobump
+  cron: "30 18-23/5 * * 1-5"  # Run at 10:30 and 15:30 PST (18:05 UTC, fall) Mon-Fri
+  cluster: prow-trusted
+  decorate: true
+  annotations:
+    testgrid-dashboards: cert-manager-testing-janitors
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Creates autobump PRs for the cert-manager/testing repo.
+  extra_refs:
+  - org: cert-manager
+    repo: testing
+    base_ref: master
+  labels:
+    preset-deployer-github-token: "true"
+    preset-deployer-ssh-key: "true"
+  spec:
+    containers:
+    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20250410-b8e0bd8d4
+      command:
+      - generic-autobumper
+      args:
+      - --config=config/autobump-config/testing-autobump-config.yaml
+      - --signoff
+
+- name: periodic-testing-label-sync
+  cron: "17 * * * *"  # Every hour at 17 minutes past the hour
+  cluster: prow-trusted
+  decorate: true
+  annotations:
+    testgrid-dashboards: cert-manager-testing-janitors
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs label_sync to synchronize GitHub repo labels with the label config defined in label_sync/labels.yaml.
+  extra_refs:
+  - org: cert-manager
+    repo: testing
+    base_ref: master
+  spec:
+    containers:
+    - name: label-sync
+      image: gcr.io/k8s-staging-test-infra/label_sync:v20250306-095fc63a16
+      command:
+      - label_sync
+      args:
+      - --config=config/labels.yaml
+      # TODO: enable label_sync across the whole org
+      - --only=cert-manager/cert-manager,cert-manager/website,cert-manager/release,cert-manager/istio-csr,cert-manager/approver-policy,cert-manager/trust-manager,cert-manager/webhook-cert-lib,cert-manager/issuer-lib,cert-manager/csi-driver,cert-manager/csi-driver-spiffe,cert-manager/openshift-routes,cert-manager/cert-manager-olm,cert-manager/webhook-lib,cert-manager/csi-lib,cert-manager/sample-external-issuer,cert-manager/cmctl,cert-manager/infrastructure,cert-manager/testing,cert-manager/makefile-modules,cert-manager/helm-tool,cert-manager/image-tool,cert-manager/community,cert-manager/webhook-example,cert-manager/org,cert-manager/base-images,cert-manager/klone,cert-manager/boilersuite,cert-manager/google-cas-issuer
+      - --debug
+      - --confirm
+      - --github-app-id=$(GITHUB_APP_ID)
+      - --github-app-private-key-path=/etc/github/cert
+      - --github-endpoint=http://ghproxy.default
+      - --github-endpoint=https://api.github.com
+      env:
+      - name: GITHUB_APP_ID
+        valueFrom:
+          secretKeyRef:
+            name: github-app-token
+            key: appid
+      volumeMounts:
+      - name: github-app-token
+        mountPath: /etc/github
+        readOnly: true
+    volumes:
+    - name: github-app-token
+      secret:
+        secretName: github-app-token
+
+- name: periodic-testing-branchprotector
+  cron: "54 * * * *"  # Every hour at 54 minutes past the hour
+  cluster: prow-trusted
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  annotations:
+    testgrid-dashboards: cert-manager-testing-janitors
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    description: Runs Prow's branchprotector to apply configured GitHub status context requirements and merge policies.
+  extra_refs:
+  - org: cert-manager
+    repo: testing
+    base_ref: master
+  spec:
+    containers:
+    - name: branchprotector
+      image: us-docker.pkg.dev/k8s-infra-prow/images/branchprotector:v20250410-b8e0bd8d4
+      command:
+      - branchprotector
+      args:
+      - --config-path=config/config.yaml
+      - --job-config-path=config/jobs
+      - --confirm
+      - --github-app-id=$(GITHUB_APP_ID)
+      - --github-app-private-key-path=/etc/github/cert
+      - --github-endpoint=http://ghproxy.default
+      - --github-endpoint=https://api.github.com
+      env:
+      - name: GITHUB_APP_ID
+        valueFrom:
+          secretKeyRef:
+            name: github-app-token
+            key: appid
+      volumeMounts:
+      - name: github-app-token
+        mountPath: /etc/github
+        readOnly: true
+    volumes:
+    - name: github-app-token
+      secret:
+        secretName: github-app-token

--- a/config/jobs/testing/testing-periodics-trusted.yaml
+++ b/config/jobs/testing/testing-periodics-trusted.yaml
@@ -7,7 +7,7 @@ periodics:
   annotations:
     testgrid-dashboards: cert-manager-testing-janitors
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Closes PRs and issues that are marked 'rotten' and have been inactive for 2y
+    description: Closes PRs and issues that are marked 'rotten' and have been inactive for 3m
   labels:
     preset-deployer-github-token: "true"
   spec:
@@ -20,10 +20,10 @@ periodics:
         --query=repo:cert-manager/cert-manager repo:cert-manager/trust-manager
         -label:lifecycle/frozen
         label:lifecycle/rotten
-      - --updated=17520h # 2 years
+      - --updated=2184h # 3 months
       - --token=/etc/github/token
       - |-
-        --comment=Rotten issues close after 2y of inactivity.
+        --comment=Rotten issues close after 3m of inactivity.
         Reopen the issue with `/reopen`.
         Mark the issue as fresh with `/remove-lifecycle rotten`.
         /close
@@ -37,7 +37,7 @@ periodics:
   annotations:
     testgrid-dashboards: cert-manager-testing-janitors
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Marks PRs and issues that are marked 'stale' and have been inactive for 1.5y as 'rotten'
+    description: Marks PRs and issues that are marked 'stale' and have been inactive for 3m as 'rotten'
   labels:
     preset-deployer-github-token: "true"
   spec:
@@ -51,12 +51,12 @@ periodics:
         -label:lifecycle/frozen
         label:lifecycle/stale
         -label:lifecycle/rotten
-      - --updated=13140h # 1.5 years
+      - --updated=2184h # 3 months
       - --token=/etc/github/token
       - |-
-        --comment=Stale issues rot after 1.5y of inactivity.
+        --comment=Stale issues rot after 3m of inactivity.
         Mark the issue as fresh with `/remove-lifecycle rotten`.
-        Rotten issues close after an additional 6m of inactivity.
+        Rotten issues close after an additional 3m of inactivity.
         If this issue is safe to close now please do so with `/close`.
         /lifecycle rotten
         /remove-lifecycle stale
@@ -70,7 +70,7 @@ periodics:
   annotations:
     testgrid-dashboards: cert-manager-testing-janitors
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Marks PRs and issues that have been inactive for 1y as 'stale'
+    description: Marks PRs and issues that have been inactive for 6m as 'stale'
   labels:
     preset-deployer-github-token: "true"
   spec:
@@ -84,12 +84,12 @@ periodics:
         -label:lifecycle/frozen
         -label:lifecycle/stale
         -label:lifecycle/rotten
-      - --updated=8760h # 1 year
+      - --updated=4368h # 6 months
       - --token=/etc/github/token
       - |-
-        --comment=Issues go stale after 1y of inactivity.
+        --comment=Issues go stale after 6m of inactivity.
         Mark the issue as fresh with `/remove-lifecycle stale`.
-        Stale issues rot after an additional 6m of inactivity and eventually close.
+        Stale issues rot after an additional 3m of inactivity and eventually close.
         If this issue is safe to close now please do so with `/close`.
         /lifecycle stale
       - --ceiling=10

--- a/config/jobs/testing/testing-periodics-trusted.yaml
+++ b/config/jobs/testing/testing-periodics-trusted.yaml
@@ -7,7 +7,7 @@ periodics:
   annotations:
     testgrid-dashboards: cert-manager-testing-janitors
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Closes PRs and issues that are marked 'rotten' and have been inactive for 30d
+    description: Closes PRs and issues that are marked 'rotten' and have been inactive for 2y
   labels:
     preset-deployer-github-token: "true"
   spec:
@@ -20,10 +20,10 @@ periodics:
         --query=repo:cert-manager/cert-manager repo:cert-manager/trust-manager
         -label:lifecycle/frozen
         label:lifecycle/rotten
-      - --updated=720h
+      - --updated=17520h # 2 years
       - --token=/etc/github/token
       - |-
-        --comment=Rotten issues close after 30d of inactivity.
+        --comment=Rotten issues close after 2y of inactivity.
         Reopen the issue with `/reopen`.
         Mark the issue as fresh with `/remove-lifecycle rotten`.
         /close
@@ -37,7 +37,7 @@ periodics:
   annotations:
     testgrid-dashboards: cert-manager-testing-janitors
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Marks PRs and issues that are marked 'stale' and have been inactive for 30d as 'rotten'
+    description: Marks PRs and issues that are marked 'stale' and have been inactive for 1.5y as 'rotten'
   labels:
     preset-deployer-github-token: "true"
   spec:
@@ -51,12 +51,12 @@ periodics:
         -label:lifecycle/frozen
         label:lifecycle/stale
         -label:lifecycle/rotten
-      - --updated=720h
+      - --updated=13140h # 1.5 years
       - --token=/etc/github/token
       - |-
-        --comment=Stale issues rot after 30d of inactivity.
+        --comment=Stale issues rot after 1.5y of inactivity.
         Mark the issue as fresh with `/remove-lifecycle rotten`.
-        Rotten issues close after an additional 30d of inactivity.
+        Rotten issues close after an additional 6m of inactivity.
         If this issue is safe to close now please do so with `/close`.
         /lifecycle rotten
         /remove-lifecycle stale
@@ -70,7 +70,7 @@ periodics:
   annotations:
     testgrid-dashboards: cert-manager-testing-janitors
     testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Marks PRs and issues that have been inactive for 30d as 'stale'
+    description: Marks PRs and issues that have been inactive for 1y as 'stale'
   labels:
     preset-deployer-github-token: "true"
   spec:
@@ -84,123 +84,13 @@ periodics:
         -label:lifecycle/frozen
         -label:lifecycle/stale
         -label:lifecycle/rotten
-      - --updated=2160h
+      - --updated=8760h # 1 year
       - --token=/etc/github/token
       - |-
-        --comment=Issues go stale after 90d of inactivity.
+        --comment=Issues go stale after 1y of inactivity.
         Mark the issue as fresh with `/remove-lifecycle stale`.
-        Stale issues rot after an additional 30d of inactivity and eventually close.
+        Stale issues rot after an additional 6m of inactivity and eventually close.
         If this issue is safe to close now please do so with `/close`.
         /lifecycle stale
       - --ceiling=10
       - --confirm
-
-- name: periodic-testing-autobump
-  cron: "30 18-23/5 * * 1-5"  # Run at 10:30 and 15:30 PST (18:05 UTC, fall) Mon-Fri
-  cluster: prow-trusted
-  decorate: true
-  annotations:
-    testgrid-dashboards: cert-manager-testing-janitors
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Creates autobump PRs for the cert-manager/testing repo.
-  extra_refs:
-  - org: cert-manager
-    repo: testing
-    base_ref: master
-  labels:
-    preset-deployer-github-token: "true"
-    preset-deployer-ssh-key: "true"
-  spec:
-    containers:
-    - image: us-docker.pkg.dev/k8s-infra-prow/images/generic-autobumper:v20250410-b8e0bd8d4
-      command:
-      - generic-autobumper
-      args:
-      - --config=config/autobump-config/testing-autobump-config.yaml
-      - --signoff
-
-- name: periodic-testing-label-sync
-  cron: "17 * * * *"  # Every hour at 17 minutes past the hour
-  cluster: prow-trusted
-  decorate: true
-  annotations:
-    testgrid-dashboards: cert-manager-testing-janitors
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs label_sync to synchronize GitHub repo labels with the label config defined in label_sync/labels.yaml.
-  extra_refs:
-  - org: cert-manager
-    repo: testing
-    base_ref: master
-  spec:
-    containers:
-    - name: label-sync
-      image: gcr.io/k8s-staging-test-infra/label_sync:v20250306-095fc63a16
-      command:
-      - label_sync
-      args:
-      - --config=config/labels.yaml
-      # TODO: enable label_sync across the whole org
-      - --only=cert-manager/cert-manager,cert-manager/website,cert-manager/release,cert-manager/istio-csr,cert-manager/approver-policy,cert-manager/trust-manager,cert-manager/webhook-cert-lib,cert-manager/issuer-lib,cert-manager/csi-driver,cert-manager/csi-driver-spiffe,cert-manager/openshift-routes,cert-manager/cert-manager-olm,cert-manager/webhook-lib,cert-manager/csi-lib,cert-manager/sample-external-issuer,cert-manager/cmctl,cert-manager/infrastructure,cert-manager/testing,cert-manager/makefile-modules,cert-manager/helm-tool,cert-manager/image-tool,cert-manager/community,cert-manager/webhook-example,cert-manager/org,cert-manager/base-images,cert-manager/klone,cert-manager/boilersuite,cert-manager/google-cas-issuer
-      - --debug
-      - --confirm
-      - --github-app-id=$(GITHUB_APP_ID)
-      - --github-app-private-key-path=/etc/github/cert
-      - --github-endpoint=http://ghproxy.default
-      - --github-endpoint=https://api.github.com
-      env:
-      - name: GITHUB_APP_ID
-        valueFrom:
-          secretKeyRef:
-            name: github-app-token
-            key: appid
-      volumeMounts:
-      - name: github-app-token
-        mountPath: /etc/github
-        readOnly: true
-    volumes:
-    - name: github-app-token
-      secret:
-        secretName: github-app-token
-
-- name: periodic-testing-branchprotector
-  cron: "54 * * * *"  # Every hour at 54 minutes past the hour
-  cluster: prow-trusted
-  decorate: true
-  decoration_config:
-    timeout: 5h
-  annotations:
-    testgrid-dashboards: cert-manager-testing-janitors
-    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
-    description: Runs Prow's branchprotector to apply configured GitHub status context requirements and merge policies.
-  extra_refs:
-  - org: cert-manager
-    repo: testing
-    base_ref: master
-  spec:
-    containers:
-    - name: branchprotector
-      image: us-docker.pkg.dev/k8s-infra-prow/images/branchprotector:v20250410-b8e0bd8d4
-      command:
-      - branchprotector
-      args:
-      - --config-path=config/config.yaml
-      - --job-config-path=config/jobs
-      - --confirm
-      - --github-app-id=$(GITHUB_APP_ID)
-      - --github-app-private-key-path=/etc/github/cert
-      - --github-endpoint=http://ghproxy.default
-      - --github-endpoint=https://api.github.com
-      env:
-      - name: GITHUB_APP_ID
-        valueFrom:
-          secretKeyRef:
-            name: github-app-token
-            key: appid
-      volumeMounts:
-      - name: github-app-token
-        mountPath: /etc/github
-        readOnly: true
-    volumes:
-    - name: github-app-token
-      secret:
-        secretName: github-app-token


### PR DESCRIPTION
[Slack thread](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1751963513710889).

I'm annoyed at our stale bot.

We originally turned it on because we (Venafi) used to look at the number of open issues as a vanity metric to tell us that we are doing a good job.... but:

1. We no longer look at this number.
2. These tons of stale messages everywhere are super verbose and annoying.

I suggest issues and PRs become stale after one year, and close them after 2 years. That should reduce the number of stale messages, but still be useful.

Before:

```
|---------90d----------|----30d----|----30d----|              total = 5 months
active                  stale       rotten     closed
```

After:

```
|------6 months--------|---3mo---|---3mo---|                  total = 1 year
active                 stale     rotten    closed
```