### PR TITLE
Preparing k8s v1.34 test suite

### DIFF
--- a/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
+++ b/config/jobs/cert-manager/cert-manager/master/cert-manager-master.yaml
@@ -202,6 +202,50 @@ presubmits:
     - master
     always_run: false
     optional: true
+  - name: pull-cert-manager-master-e2e-v1-34
+    max_concurrency: 4
+    decorate: true
+    annotations:
+      description: Runs the end-to-end test suite against a Kubernetes v1.34 cluster
+      testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+      testgrid-create-job-group: "true"
+      testgrid-dashboards: cert-manager-presubmits-master
+    labels:
+      preset-cloudflare-credentials: "true"
+      preset-dind-enabled: "true"
+      preset-enable-all-feature-gates: "true"
+      preset-ginkgo-skip-default: "true"
+      preset-go-cache: "true"
+      preset-local-cache: "true"
+      preset-retry-flakey-jobs: "true"
+    spec:
+      containers:
+      - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20250327-af35b2b-bookworm
+        args:
+        - runner
+        - make
+        - -j7
+        - vendor-go
+        - e2e-ci
+        - K8S_VERSION=1.34
+        resources:
+          requests:
+            cpu: 7000m
+            memory: 6Gi
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_ADMIN
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 8.8.4.4
+    branches:
+    - master
+    always_run: false
+    optional: true
   - name: pull-cert-manager-master-e2e-v1-33
     max_concurrency: 4
     decorate: true
@@ -665,6 +709,51 @@ periodics:
     repo: cert-manager
     base_ref: master
   cron: 12 01-23/02 * * *
+- name: ci-cert-manager-master-e2e-v1-34
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the end-to-end test suite against a Kubernetes v1.34 cluster
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-master
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-enable-all-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20250327-af35b2b-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.34
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  cron: 16 00-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-33
   max_concurrency: 4
   decorate: true
@@ -709,7 +798,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 16 00-23/02 * * *
+  cron: 20 01-23/02 * * *
 - name: ci-cert-manager-master-e2e-v1-33-issuers-venafi
   max_concurrency: 4
   decorate: true
@@ -754,7 +843,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 20 00-23/12 * * *
+  cron: 24 00-23/12 * * *
 - name: ci-cert-manager-master-e2e-v1-33-upgrade
   max_concurrency: 4
   decorate: true
@@ -794,7 +883,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 24 00-23/08 * * *
+  cron: 28 00-23/08 * * *
 - name: ci-cert-manager-master-e2e-v1-33-bestpractice-install
   max_concurrency: 4
   decorate: true
@@ -841,7 +930,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 28 00-23/24 * * *
+  cron: 32 00-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-30-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -886,7 +975,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 32 07-23/24 * * *
+  cron: 36 07-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-31-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -931,7 +1020,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 36 14-23/24 * * *
+  cron: 40 14-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-32-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -976,7 +1065,52 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 40 21-23/24 * * *
+  cron: 44 21-23/24 * * *
+- name: ci-cert-manager-master-e2e-v1-34-feature-gates-disabled
+  max_concurrency: 4
+  decorate: true
+  annotations:
+    description: Runs the E2E tests with all feature gates disabled
+    testgrid-alert-email: cert-manager-dev-alerts@googlegroups.com
+    testgrid-create-job-group: "true"
+    testgrid-dashboards: cert-manager-periodics-master
+  labels:
+    preset-cloudflare-credentials: "true"
+    preset-dind-enabled: "true"
+    preset-disable-all-alpha-beta-feature-gates: "true"
+    preset-ginkgo-skip-default: "true"
+    preset-go-cache: "true"
+    preset-local-cache: "true"
+    preset-retry-flakey-jobs: "true"
+  spec:
+    containers:
+    - image: europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/make-dind:20250327-af35b2b-bookworm
+      args:
+      - runner
+      - make
+      - -j7
+      - vendor-go
+      - e2e-ci
+      - K8S_VERSION=1.34
+      resources:
+        requests:
+          cpu: 7000m
+          memory: 6Gi
+      securityContext:
+        privileged: true
+        capabilities:
+          add:
+          - SYS_ADMIN
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 8.8.8.8
+      - 8.8.4.4
+  extra_refs:
+  - org: cert-manager
+    repo: cert-manager
+    base_ref: master
+  cron: 48 04-23/24 * * *
 - name: ci-cert-manager-master-e2e-v1-33-feature-gates-disabled
   max_concurrency: 4
   decorate: true
@@ -1021,7 +1155,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 44 04-23/24 * * *
+  cron: 52 11-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-controller
   max_concurrency: 2
   decorate: true
@@ -1061,7 +1195,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 48 11-23/24 * * *
+  cron: 56 18-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-acmesolver
   max_concurrency: 2
   decorate: true
@@ -1101,7 +1235,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 52 18-23/24 * * *
+  cron: 00 01-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-startupapicheck
   max_concurrency: 2
   decorate: true
@@ -1141,7 +1275,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 56 01-23/24 * * *
+  cron: 04 08-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-cainjector
   max_concurrency: 2
   decorate: true
@@ -1181,7 +1315,7 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 00 08-23/24 * * *
+  cron: 08 15-23/24 * * *
 - name: ci-cert-manager-master-trivy-test-webhook
   max_concurrency: 2
   decorate: true
@@ -1221,4 +1355,4 @@ periodics:
   - org: cert-manager
     repo: cert-manager
     base_ref: master
-  cron: 04 15-23/24 * * *
+  cron: 12 22-23/24 * * *

--- a/config/prowgen/prowspecs/specs.go
+++ b/config/prowgen/prowspecs/specs.go
@@ -90,7 +90,7 @@ var knownBranches map[string]BranchSpec = map[string]BranchSpec{
 		},
 
 		primaryKubernetesVersion: "1.33",
-		otherKubernetesVersions:  []string{"1.30", "1.31", "1.32"},
+		otherKubernetesVersions:  []string{"1.30", "1.31", "1.32", "1.34"},
 
 		e2eCPURequest:    "7000m",
 		e2eMemoryRequest: "6Gi",


### PR DESCRIPTION
Adds optional tests so that we can test our CI for k8s 1.34 before making it default