### PR TITLE
Update c-m required checks to K8s 1.34

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -99,8 +99,8 @@ branch-protection:
                 contexts:
                 - pull-cert-manager-master-make-verify
                 - pull-cert-manager-master-make-test
-                - pull-cert-manager-master-e2e-v1-33
-                - pull-cert-manager-master-e2e-v1-33-upgrade
+                - pull-cert-manager-master-e2e-v1-34
+                - pull-cert-manager-master-e2e-v1-34-upgrade
         website:
           required_status_checks:
             contexts:


### PR DESCRIPTION
There was an important change missing from https://github.com/cert-manager/testing/pull/1109. The required checks were not updated to the new default K8s version. This appears to block CI in cert-manager.

/cc @inteon 