### PR TITLE
Remove archived cert-manager/webhook-lib configuration

### DIFF
--- a/config/jobs/testing/testing-periodics-trusted.yaml
+++ b/config/jobs/testing/testing-periodics-trusted.yaml
@@ -140,7 +140,7 @@ periodics:
       args:
       - --config=config/labels.yaml
       # TODO: enable label_sync across the whole org
-      - --only=cert-manager/cert-manager,cert-manager/website,cert-manager/release,cert-manager/istio-csr,cert-manager/approver-policy,cert-manager/trust-manager,cert-manager/trust-manager-csi-driver,cert-manager/webhook-cert-lib,cert-manager/issuer-lib,cert-manager/csi-driver,cert-manager/csi-driver-spiffe,cert-manager/openshift-routes,cert-manager/webhook-lib,cert-manager/csi-lib,cert-manager/sample-external-issuer,cert-manager/cmctl,cert-manager/infrastructure,cert-manager/testing,cert-manager/makefile-modules,cert-manager/helm-tool,cert-manager/image-tool,cert-manager/community,cert-manager/webhook-example,cert-manager/org,cert-manager/base-images,cert-manager/klone,cert-manager/boilersuite,cert-manager/google-cas-issuer
+      - --only=cert-manager/cert-manager,cert-manager/website,cert-manager/release,cert-manager/istio-csr,cert-manager/approver-policy,cert-manager/trust-manager,cert-manager/trust-manager-csi-driver,cert-manager/webhook-cert-lib,cert-manager/issuer-lib,cert-manager/csi-driver,cert-manager/csi-driver-spiffe,cert-manager/openshift-routes,cert-manager/csi-lib,cert-manager/sample-external-issuer,cert-manager/cmctl,cert-manager/infrastructure,cert-manager/testing,cert-manager/makefile-modules,cert-manager/helm-tool,cert-manager/image-tool,cert-manager/community,cert-manager/webhook-example,cert-manager/org,cert-manager/base-images,cert-manager/klone,cert-manager/boilersuite,cert-manager/google-cas-issuer
       - --debug
       - --confirm
       - --github-app-id=$(GITHUB_APP_ID)

--- a/triage_party/triageparty_configmap.yaml
+++ b/triage_party/triageparty_configmap.yaml
@@ -35,7 +35,6 @@ data:
         - https://github.com/cert-manager/csi-driver
         - https://github.com/cert-manager/csi-driver-spiffe
         - https://github.com/cert-manager/openshift-routes
-        - https://github.com/cert-manager/webhook-lib
         - https://github.com/cert-manager/csi-lib
         - https://github.com/cert-manager/sample-external-issuer
         - https://github.com/cert-manager/cmctl


### PR DESCRIPTION
The label-sync job is still failing. Now, because https://github.com/cert-manager/webhook-lib is archived.

/cc @inteon 